### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b769bd2b01bce5afe0af703218593355c6f52337",
-        "sha256": "1ngsl0acsym0srsirf0c118v02s2c7mxzisha3l3665znqd7fmjq",
+        "rev": "d431839ab4494499714f2b6f001413fe380607eb",
+        "sha256": "0liwhzy3rai0vxxa8985f1aw4y3ha39vgkfjslbsf5h79f3xf8im",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b769bd2b01bce5afe0af703218593355c6f52337.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d431839ab4494499714f2b6f001413fe380607eb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        | Timestamp              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------------------- |
| [`d431839a`](https://github.com/NixOS/nixpkgs/commit/d431839ab4494499714f2b6f001413fe380607eb) | `lima: 0.6.1 -> 0.6.2`                                                | `2021-09-04 06:14:53Z` |
| [`0f1a3661`](https://github.com/NixOS/nixpkgs/commit/0f1a3661f12b23e066b73909a07e36b60e824893) | `meilisearch: add wrapper derivation for renaming`                    | `2021-09-04 03:03:36Z` |
| [`c9f0c6f1`](https://github.com/NixOS/nixpkgs/commit/c9f0c6f115f4369b5047c3c3086518294541d0bf) | `build-rust-crate: add global libiconv darwin buildInputs`            | `2021-09-04 03:03:36Z` |
| [`0585c981`](https://github.com/NixOS/nixpkgs/commit/0585c981f11a7bfcef79f386000a8219e819e169) | `build-rust-crate: nixpkgs-fmt`                                       | `2021-09-04 03:03:36Z` |
| [`0e8d59e3`](https://github.com/NixOS/nixpkgs/commit/0e8d59e3cbb11d1157761890e993d0725483be9d) | `default-crate-overrides: nixpkgs-fmt`                                | `2021-09-04 03:03:36Z` |
| [`3584ad8d`](https://github.com/NixOS/nixpkgs/commit/3584ad8d5754b74185be2c43c6eb24ea4db90fd8) | `meilisearch: 0.9.0 -> 0.21.1`                                        | `2021-09-04 03:03:36Z` |
| [`3a77817e`](https://github.com/NixOS/nixpkgs/commit/3a77817ee97720d1fe6d780d2ed5fad49b0d5435) | `gitea: 1.15.0 -> 1.15.2`                                             | `2021-09-03 22:58:30Z` |
| [`702d1834`](https://github.com/NixOS/nixpkgs/commit/702d1834218e483ab630a3414a47f3a537f94182) | `lemmy: 0.11.2 -> 0.11.3`                                             | `2021-09-03 22:50:53Z` |
| [`af406de8`](https://github.com/NixOS/nixpkgs/commit/af406de8b10d378e7bdd955fb3197de6a7fcf525) | `python38Packages.transitions: 0.8.8 -> 0.8.9`                        | `2021-09-03 22:48:32Z` |
| [`1e548583`](https://github.com/NixOS/nixpkgs/commit/1e548583afc8623702daab75ad447f383b32717f) | `wrangler: 0.19.1 -> 0.19.2`                                          | `2021-09-03 22:47:34Z` |
| [`6c4ac973`](https://github.com/NixOS/nixpkgs/commit/6c4ac973a3d3f8bcc31daf114061a8afdc35bfd9) | `nmap-formatter: init at 0.2.1`                                       | `2021-09-03 22:46:25Z` |
| [`57d17c2a`](https://github.com/NixOS/nixpkgs/commit/57d17c2abe0b109a69b1efdfda726204a7eab818) | `gokart: init at 0.2.0`                                               | `2021-09-03 22:45:59Z` |
| [`c0d30989`](https://github.com/NixOS/nixpkgs/commit/c0d3098932cd51cd55ef9b7bd7e3c8bf6d1aa17f) | `erlangR24: 24.0.5 -> 24.0.6`                                         | `2021-09-03 22:20:23Z` |
| [`1fa84e3e`](https://github.com/NixOS/nixpkgs/commit/1fa84e3e027e8a830f129b58439db7c037530d75) | `vimPlugins: split doc generation into a hook`                        | `2021-09-03 22:12:35Z` |
| [`9dea9867`](https://github.com/NixOS/nixpkgs/commit/9dea98679d45d22c85ff2fc5d190ebbe5b03d6bc) | `python38Packages.google-cloud-datacatalog: 3.4.0 -> 3.4.1`           | `2021-09-03 21:53:55Z` |
| [`717cbf8e`](https://github.com/NixOS/nixpkgs/commit/717cbf8e7dcd14d97125cc1176d43c5dabc5c933) | `python38Packages.eventlet: 0.31.1 -> 0.32.0`                         | `2021-09-03 21:51:38Z` |
| [`2a5f23d0`](https://github.com/NixOS/nixpkgs/commit/2a5f23d0e5e4bba82267027d1c6246f05ced7b3b) | `python38Packages.mechanize: 0.4.5 -> 0.4.6`                          | `2021-09-03 21:50:28Z` |
| [`dcd65ace`](https://github.com/NixOS/nixpkgs/commit/dcd65ace3c6cbb48511ebc25de5df31cb8483b6a) | `python38Packages.elasticsearch: 7.14.0 -> 7.14.1`                    | `2021-09-03 21:40:47Z` |
| [`adbd7680`](https://github.com/NixOS/nixpkgs/commit/adbd7680a43ae5e324c01f2655e269e71f979a10) | `python38Packages.pyacoustid: 1.2.1 -> 1.2.2`                         | `2021-09-03 21:39:51Z` |
| [`585fe114`](https://github.com/NixOS/nixpkgs/commit/585fe1146f1a6715ddb83b73e6212d3653feec88) | `python38Packages.cucumber-tag-expressions: 3.0.1 -> 4.0.0`           | `2021-09-03 21:39:08Z` |
| [`cb8e60d3`](https://github.com/NixOS/nixpkgs/commit/cb8e60d31c2f9a9231dc01da25908245616ed62d) | `python38Packages.mwparserfromhell: 0.6.2 -> 0.6.3`                   | `2021-09-03 21:38:49Z` |
| [`af0c4eb5`](https://github.com/NixOS/nixpkgs/commit/af0c4eb5eab666bd4c130eb4fc305f5ddf6acd12) | `python38Packages.elementpath: 2.2.3 -> 2.3.0`                        | `2021-09-03 21:32:38Z` |
| [`c615ff0a`](https://github.com/NixOS/nixpkgs/commit/c615ff0a8ce147db37fdaa7622d85dc7c1cec253) | `python38Packages.google-re2: 0.2.20210801 -> 0.2.20210901`           | `2021-09-03 21:32:21Z` |
| [`4fe1ffec`](https://github.com/NixOS/nixpkgs/commit/4fe1ffec45d8798b1b92011e28a62a0646ae94d0) | `python38Packages.dogpile_cache: 1.1.3 -> 1.1.4`                      | `2021-09-03 21:32:04Z` |
| [`062af857`](https://github.com/NixOS/nixpkgs/commit/062af857e33197c550979dc97ca8a7e1ca6242d7) | `python38Packages.azure-mgmt-compute: 22.1.0 -> 23.0.0`               | `2021-09-03 21:30:22Z` |
| [`c5130a62`](https://github.com/NixOS/nixpkgs/commit/c5130a6205c9b89d31b7140f6478fdc9014e06ea) | `signal-desktop: 5.15.0 -> 5.16.0`                                    | `2021-09-03 21:24:53Z` |
| [`5661f7db`](https://github.com/NixOS/nixpkgs/commit/5661f7dbeeee708a401d2524ddb40374dda4c6a7) | `llvmPackages_13.compiler-rt: Mark as broken on Aarch64`              | `2021-09-03 21:13:43Z` |
| [`651d7cdc`](https://github.com/NixOS/nixpkgs/commit/651d7cdc19cec611b759a20ed6384017c75a6653) | `factorio-experimental: 1.1.38 -> 1.1.39`                             | `2021-09-03 21:11:40Z` |
| [`4ad4ae68`](https://github.com/NixOS/nixpkgs/commit/4ad4ae68c427ef8458be34051b4e545eb752811c) | `salt: 3003.2 -> 3003.3`                                              | `2021-09-03 18:31:14Z` |
| [`395d2eff`](https://github.com/NixOS/nixpkgs/commit/395d2eff174438c631592f95b8b32182fab416e2) | `linux_latest-libre: 18268 -> 18298`                                  | `2021-09-03 16:55:42Z` |
| [`979c0b77`](https://github.com/NixOS/nixpkgs/commit/979c0b77abaf3866b1d32a3cb68906fd01946840) | `linux-rt_5_4: 5.4.138-rt62 -> 5.4.143-rt63`                          | `2021-09-03 16:55:42Z` |
| [`32211147`](https://github.com/NixOS/nixpkgs/commit/32211147489cd3126fb46b21306310fb3d4e1594) | `linux: 5.4.143 -> 5.4.144`                                           | `2021-09-03 16:55:42Z` |
| [`116141a1`](https://github.com/NixOS/nixpkgs/commit/116141a18868ec3e520423cd69c8fab31442d95a) | `linux: 5.14 -> 5.14.1`                                               | `2021-09-03 16:55:42Z` |
| [`ba3f560d`](https://github.com/NixOS/nixpkgs/commit/ba3f560dc5a0cf5824c39b4eee23d2978a882622) | `linux: 5.13.13 -> 5.13.14`                                           | `2021-09-03 16:55:42Z` |
| [`f57a2e0b`](https://github.com/NixOS/nixpkgs/commit/f57a2e0bed20c180aca22dae884c3965d70cb13f) | `linux: 5.10.61 -> 5.10.62`                                           | `2021-09-03 16:55:42Z` |
| [`c57b2db4`](https://github.com/NixOS/nixpkgs/commit/c57b2db48bd112e329a56d1c55596e0805be707c) | `linux: 4.9.281 -> 4.9.282`                                           | `2021-09-03 16:55:42Z` |
| [`5ed23535`](https://github.com/NixOS/nixpkgs/commit/5ed235352a04bc73adf172cfd91d9c5a1c27db67) | `linux: 4.4.282 -> 4.4.283`                                           | `2021-09-03 16:55:42Z` |
| [`9c8dbd4a`](https://github.com/NixOS/nixpkgs/commit/9c8dbd4a1ea5b32c9ef63d97665064c7f1bea3cc) | `linux: 4.19.205 -> 4.19.206`                                         | `2021-09-03 16:55:42Z` |
| [`ad44de1d`](https://github.com/NixOS/nixpkgs/commit/ad44de1d945aab770833134d74d801b05e2208a8) | `linux: 4.14.245 -> 4.14.246`                                         | `2021-09-03 16:55:42Z` |
| [`a7532641`](https://github.com/NixOS/nixpkgs/commit/a75326417df32c0354e3244a9461700d214eab82) | `vscode,vscodium: fix moving files to the trash`                      | `2021-09-03 15:36:36Z` |
| [`51df9074`](https://github.com/NixOS/nixpkgs/commit/51df9074f00d449bad44c08d81847a06c6d9ec97) | `terraform_1_0: 1.0.5 -> 1.0.6`                                       | `2021-09-03 15:10:26Z` |
| [`b41f640f`](https://github.com/NixOS/nixpkgs/commit/b41f640fb7665c20be4afba3072a3adfadc33c4e) | `corerad: 0.3.3 -> 0.3.4`                                             | `2021-09-03 15:10:05Z` |
| [`3da2e9c3`](https://github.com/NixOS/nixpkgs/commit/3da2e9c34bf575e2449ae21626ed1a4ab351a3ce) | `shadowenv: 2.0.4 -> 2.0.5`                                           | `2021-09-03 14:55:44Z` |
| [`3da1c959`](https://github.com/NixOS/nixpkgs/commit/3da1c959408f90cb9299d383e5e48a6b2cf13cb3) | `fftw: add optional AVX/FMA optmization flags`                        | `2021-09-03 14:53:30Z` |
| [`3677d4bc`](https://github.com/NixOS/nixpkgs/commit/3677d4bc22eddac35e5a19080ec09ab387a76528) | `kexec-tools: rename from kexectools to match the project name`       | `2021-09-03 14:17:21Z` |
| [`446de3a2`](https://github.com/NixOS/nixpkgs/commit/446de3a2f3a3d04a0a16de059abee7ce4614501b) | `emacs.pkgs.ebuild-mode: 1.52 -> 1.53`                                | `2021-09-03 13:43:30Z` |
| [`5d852fef`](https://github.com/NixOS/nixpkgs/commit/5d852fef63156b965f302de98d30949258d7af23) | `haskellPackages: mark builds failing on hydra as broken`             | `2021-09-03 13:41:47Z` |
| [`ee94d2f3`](https://github.com/NixOS/nixpkgs/commit/ee94d2f39218a7b97f9421525f0f9c47ada8af4f) | `bear: 3.0.13 -> 3.0.14`                                              | `2021-09-03 13:32:26Z` |
| [`742750cc`](https://github.com/NixOS/nixpkgs/commit/742750ccfd0582cd73af272d9dd3a011fb2d6f42) | `linuxPackages.ddcci-driver: 0.3.3 -> 0.4.1`                          | `2021-09-03 13:20:34Z` |
| [`850286cb`](https://github.com/NixOS/nixpkgs/commit/850286cb9a3d010fdbbe7280721b649e2078998c) | `buildbot: fix withPlugins`                                           | `2021-09-03 12:54:46Z` |
| [`98a3230a`](https://github.com/NixOS/nixpkgs/commit/98a3230afa0ba04863c783f19e6eed389af1f338) | `remove a mention of #node.section.md`                                | `2021-09-03 12:45:20Z` |
| [`cfb993f7`](https://github.com/NixOS/nixpkgs/commit/cfb993f75586757293e884b8403c1ea7ca507dd3) | `inferno: 0.10.6 -> 0.10.7`                                           | `2021-09-03 12:44:28Z` |
| [`94c4410f`](https://github.com/NixOS/nixpkgs/commit/94c4410f7c82c19deeea9ffbefbf76fcd8dfc2dc) | `libint: make enableFMA default dependent of hostPlatform flags`      | `2021-09-03 12:15:37Z` |
| [`af9f38c2`](https://github.com/NixOS/nixpkgs/commit/af9f38c205fbcd0959169771bf65b77cc1264f81) | `zsh: fix TZ= completion`                                             | `2021-09-03 12:00:00Z` |
| [`d68d6477`](https://github.com/NixOS/nixpkgs/commit/d68d6477c2ceb855059612b48b650998ee8ca764) | `release-notes: add nats service`                                     | `2021-09-03 11:57:04Z` |
| [`f007b794`](https://github.com/NixOS/nixpkgs/commit/f007b794c758000a275b00dd0695d2fb155195f0) | `gitlab: add back grpc patch`                                         | `2021-09-03 11:23:45Z` |
| [`6ede6d27`](https://github.com/NixOS/nixpkgs/commit/6ede6d2740c0625531b58d69d5a80a06821c6635) | `gitlab: 14.2.1 -> 14.2.3`                                            | `2021-09-03 11:23:40Z` |
| [`d14e9188`](https://github.com/NixOS/nixpkgs/commit/d14e9188d1cd88f1b530bf860638c2de27486a6d) | `gitaly: Fix gitaly-git2go binary name (#136569)`                     | `2021-09-03 11:23:00Z` |
| [`b891957a`](https://github.com/NixOS/nixpkgs/commit/b891957a976e4118322b36ab9e312e79925ec5d8) | `Allow to execute update script in CI environment`                    | `2021-09-03 10:35:12Z` |
| [`afaced27`](https://github.com/NixOS/nixpkgs/commit/afaced27467b0916f8251830d7514b5f140c782d) | `thunderbird: patch for #134433`                                      | `2021-09-03 10:23:08Z` |
| [`79725cdc`](https://github.com/NixOS/nixpkgs/commit/79725cdc4d81395191a3603a61fdb14eb739b9cf) | `chromiumDev: 95.0.4621.4 -> 95.0.4628.3`                             | `2021-09-03 09:50:29Z` |
| [`86d18d9c`](https://github.com/NixOS/nixpkgs/commit/86d18d9c53066e8cdbf76d69e5a624ad3ad4187e) | `buildpack: 0.18.0 -> 0.20.0`                                         | `2021-09-03 09:08:46Z` |
| [`ca02868d`](https://github.com/NixOS/nixpkgs/commit/ca02868dda125a0de9d03ab920736fc8cd829451) | `python38Packages.pefile: 2021.5.24 -> 2021.9.2`                      | `2021-09-03 09:05:40Z` |
| [`cd9582b5`](https://github.com/NixOS/nixpkgs/commit/cd9582b575884ce2c4b873c56b63316fae5b81d9) | `hotspot: add rustc-demangle and zstd support`                        | `2021-09-03 08:56:47Z` |
| [`9533cd49`](https://github.com/NixOS/nixpkgs/commit/9533cd493cd728ad726d89cbec1683f0296f4877) | `kddockwidgets: init at 1.4.0`                                        | `2021-09-03 08:56:46Z` |
| [`979d0bbe`](https://github.com/NixOS/nixpkgs/commit/979d0bbe72c6ba0a9b97cb2a769f5622354dc2f3) | `rustc-demangle: init at 0.1.20`                                      | `2021-09-03 08:56:37Z` |
| [`dcbe696f`](https://github.com/NixOS/nixpkgs/commit/dcbe696fa80853e6c3b81af00cd0118074a8fc05) | `python38Packages.sqlmap: 1.5.8 -> 1.5.9`                             | `2021-09-03 08:40:38Z` |
| [`10465d1e`](https://github.com/NixOS/nixpkgs/commit/10465d1e16fe8679d3ca7dfbd1013b4629d9bfeb) | `maintainers: add 1000teslas`                                         | `2021-09-03 08:38:49Z` |
| [`0eaaf539`](https://github.com/NixOS/nixpkgs/commit/0eaaf539d867f5a41d9ee7014667ba5686b42a65) | `python3Packages.protonup: init at 0.1.4`                             | `2021-09-03 05:17:26Z` |
| [`cff78eba`](https://github.com/NixOS/nixpkgs/commit/cff78ebaf61e3b13e46735707904e980deaf0614) | `vscode: 1.59.1 -> 1.60.0`                                            | `2021-09-03 03:01:30Z` |
| [`5f6a5d5c`](https://github.com/NixOS/nixpkgs/commit/5f6a5d5c5f52c5accbf109872bb4957c53dc1e7e) | `ran: init at 0.1.6`                                                  | `2021-09-03 02:44:03Z` |
| [`8cbcf42a`](https://github.com/NixOS/nixpkgs/commit/8cbcf42add31ded197b5789cb0959e8abc40654c) | `inetutils: 2.0 -> 2.2`                                               | `2021-09-03 01:33:46Z` |
| [`5480cb98`](https://github.com/NixOS/nixpkgs/commit/5480cb98ecadbad9a981d7becb0988a8d7e46612) | `materialize: 0.8.1 -> 0.8.3`                                         | `2021-09-03 01:31:26Z` |
| [`6f7fc1c6`](https://github.com/NixOS/nixpkgs/commit/6f7fc1c693889e4322a410652a698673b346e578) | `nixos.matrix-synapse: Clarify documentation of server_name.`         | `2021-09-03 01:27:00Z` |
| [`3f2bdc19`](https://github.com/NixOS/nixpkgs/commit/3f2bdc19c135ce1489f36259e1766263337588af) | `python3Packages.policyuniverse: 1.4.0.20210816 -> 1.4.0.20210819`    | `2021-09-02 21:07:25Z` |
| [`754d0362`](https://github.com/NixOS/nixpkgs/commit/754d0362cc247115719fcc642dc6c7a6f2e38326) | `tealdeer: add meta.mainProgram`                                      | `2021-09-02 20:58:23Z` |
| [`a9667fc8`](https://github.com/NixOS/nixpkgs/commit/a9667fc80fbd5b7ba49c025fbf8cfe121acef68d) | `luarocks: add bash/zsh completion`                                   | `2021-09-02 20:57:06Z` |
| [`225637dd`](https://github.com/NixOS/nixpkgs/commit/225637dd596c14f63a5b9ebf54accd6e44997df1) | `yt-dlp: 2021.08.10 -> 2021.9.2`                                      | `2021-09-02 20:49:03Z` |
| [`ab1d85c0`](https://github.com/NixOS/nixpkgs/commit/ab1d85c0b1393e6cd513770166613e105aa4ac8d) | `Revert "linuxPackages.zfs: fix m4 script when not using GCC"`        | `2021-09-02 20:45:53Z` |
| [`a12606be`](https://github.com/NixOS/nixpkgs/commit/a12606bef42e79184c18e89146df6319e4715884) | `linuxPackages.zfs: use the kernel's stdenv when possible`            | `2021-09-02 20:45:52Z` |
| [`379f0308`](https://github.com/NixOS/nixpkgs/commit/379f030887d67a2bd610e95ef402a016a0a89d78) | `cope: fix version number`                                            | `2021-09-02 18:31:27Z` |
| [`ecbecedb`](https://github.com/NixOS/nixpkgs/commit/ecbecedb0d140c4e2ca0c2b26ce7750d5883aabd) | `python3Packages.haversine: 2.4.0 -> 2.5.1`                           | `2021-09-02 18:31:06Z` |
| [`682ed181`](https://github.com/NixOS/nixpkgs/commit/682ed1816c728f184164d099b6097317951640c8) | `python3Packages.time-machine: 2.3.1 -> 2.4.0`                        | `2021-09-02 17:06:17Z` |
| [`4194d02d`](https://github.com/NixOS/nixpkgs/commit/4194d02deb6c3bd60dffe752b4b788570553a649) | `jitsi-meet-electron: 2.8.10 -> 2.8.11 (#136197)`                     | `2021-09-02 16:35:46Z` |
| [`4cc490da`](https://github.com/NixOS/nixpkgs/commit/4cc490daffa56b71694500762acc69f6d3109242) | `apt: 1.8.4 -> 2.3.8`                                                 | `2021-09-02 15:22:59Z` |
| [`756e6034`](https://github.com/NixOS/nixpkgs/commit/756e60344fd83427148d8acf416c63573404a2e9) | `nixos/pipewire: use absolute path for jack libs`                     | `2021-09-02 14:17:15Z` |
| [`aa1983c0`](https://github.com/NixOS/nixpkgs/commit/aa1983c003c8a3315b9eaa291c296d48589d3049) | `triehash: init at 0.3`                                               | `2021-09-02 14:05:28Z` |
| [`f2b50ffa`](https://github.com/NixOS/nixpkgs/commit/f2b50ffadb6b5365844003cf8f861e524ff44a8a) | `elixir-ls: 0.8.0 -> 0.8.1`                                           | `2021-09-02 14:00:02Z` |
| [`9ce8df12`](https://github.com/NixOS/nixpkgs/commit/9ce8df127d6d0b21ec3fc3864625677bb2fa73f6) | `nixos/etc: make sure local "source" files are imported to the store` | `2021-09-02 13:50:44Z` |
| [`8d356bb2`](https://github.com/NixOS/nixpkgs/commit/8d356bb2c69f1870110e5563f69eaa86d3ddc2f7) | `helvetica-neue-lt-std: cleanup`                                      | `2021-09-02 12:56:59Z` |
| [`5d87d839`](https://github.com/NixOS/nixpkgs/commit/5d87d839d1271528dfe996b49a30044b53f96c2a) | `helvetica-neue-lt-std: 2013.06.07 -> 2014.08.16`                     | `2021-09-02 12:55:38Z` |
| [`35f292e3`](https://github.com/NixOS/nixpkgs/commit/35f292e38e2cdcb867a33c1f8ad2b9808fd072b0) | `strace: 5.13 -> 5.14`                                                | `2021-09-02 12:48:42Z` |
| [`7ca49a70`](https://github.com/NixOS/nixpkgs/commit/7ca49a701a7b6a9b90738af132f6b57e4160facd) | `ntfs-3g: update homepage`                                            | `2021-09-02 10:28:36Z` |
| [`0c35c72e`](https://github.com/NixOS/nixpkgs/commit/0c35c72ed4d85da1fa3f953aa2882716bb8d6332) | `ntfs-3g: 2017.3.23 -> 2021.8.22`                                     | `2021-09-02 10:26:47Z` |
| [`55e9fc96`](https://github.com/NixOS/nixpkgs/commit/55e9fc96666eecd1d4fba29a37b6f474b60667c4) | `chromiumBeta: 94.0.4606.20 -> 94.0.4606.31`                          | `2021-09-02 09:13:49Z` |
| [`e4a8bc9b`](https://github.com/NixOS/nixpkgs/commit/e4a8bc9b944a3f4370143ee282b6dd6568b60f23) | `arpa2common: init at 2.2.14`                                         | `2021-09-02 08:34:41Z` |
| [`98659898`](https://github.com/NixOS/nixpkgs/commit/98659898959e00c285ab1711739757b19154d158) | `cargo-release: 0.17.0 -> 0.17.1`                                     | `2021-09-02 07:20:42Z` |
| [`0bab87d2`](https://github.com/NixOS/nixpkgs/commit/0bab87d2428f67aa4a6f0aca4e85aa63e8510dfb) | `flexget: 3.1.135 -> 3.1.136`                                         | `2021-09-02 05:01:51Z` |
| [`4ddc5c6b`](https://github.com/NixOS/nixpkgs/commit/4ddc5c6b2addbf03ee21fa5b51de15b2cded11c8) | `elasticsearch: remove logic for version less than 6`                 | `2021-09-02 01:57:02Z` |
| [`d58fa9e4`](https://github.com/NixOS/nixpkgs/commit/d58fa9e445d171ba8a735165dc60706d54e9cc4f) | `elasticsearch: fix jvm gc log path`                                  | `2021-09-02 01:57:02Z` |
| [`e13906ff`](https://github.com/NixOS/nixpkgs/commit/e13906fff009043e8982567ca6bc1a031b62f388) | `elasticsearch: nixpkgs-fmt`                                          | `2021-09-02 01:57:02Z` |
| [`3b7fa874`](https://github.com/NixOS/nixpkgs/commit/3b7fa8744ccb957ce20304f6b9ec68325671ae11) | `elasticsearch7: wrap elasticcearch-keystore`                         | `2021-09-02 01:57:02Z` |
| [`070fa4ce`](https://github.com/NixOS/nixpkgs/commit/070fa4cefc5b7bd0c8f95850adfcb4f0bf4bd09a) | `elixir_ls: add update script`                                        | `2021-09-02 01:55:45Z` |
| [`8d3527aa`](https://github.com/NixOS/nixpkgs/commit/8d3527aa887eb6ea4c0c2fc5a5cbe8cf0e81de2e) | `nixos/network-interfaces: Fix wlan interface mac`                    | `2021-09-02 01:46:26Z` |
| [`ea4b37e6`](https://github.com/NixOS/nixpkgs/commit/ea4b37e6790b7d3e03ee29cb050e5c76f11245ac) | `buildFhsUserenv: inherit mounts from parent namespace`               | `2021-09-02 01:37:54Z` |
| [`27a37154`](https://github.com/NixOS/nixpkgs/commit/27a37154dee56bd7eff4d33e0c1b9747e69cb4ac) | `monit: 5.27.2 -> 5.29.0; format`                                     | `2021-09-01 23:53:21Z` |
| [`3309bddc`](https://github.com/NixOS/nixpkgs/commit/3309bddc4061253df4e4d99399d926244e9807de) | `discord-canary: 0.0.128 -> 0.0.129`                                  | `2021-09-01 23:46:06Z` |
| [`33df189f`](https://github.com/NixOS/nixpkgs/commit/33df189fae1c0909feb64462e067e405c7639f3a) | `pythonPackages.fiona: fix build`                                     | `2021-09-01 22:51:41Z` |
| [`a9faf273`](https://github.com/NixOS/nixpkgs/commit/a9faf273fec06d38de8349dbfb494db82bb5f01b) | `python3Packages.tldextract: 3.1.1 -> 3.1.2`                          | `2021-09-01 21:27:00Z` |
| [`023a3fae`](https://github.com/NixOS/nixpkgs/commit/023a3fae1809788f7c2dc8fc0ccf6abbb19508dc) | `python38Packages.pex: 2.1.46 -> 2.1.47`                              | `2021-09-01 21:20:43Z` |
| [`05a5144f`](https://github.com/NixOS/nixpkgs/commit/05a5144fa9032018b9aac3a5aaf9c368b8347a4f) | `build(deps): bump devmasx/merge-branch from 1.3.1 to 1.4.0`          | `2021-09-01 21:08:00Z` |
| [`1e3fe281`](https://github.com/NixOS/nixpkgs/commit/1e3fe281f9ee69359c53ab6f9f463d22844210b9) | `nuclei: 2.4.3 -> 2.5.0`                                              | `2021-09-01 21:04:09Z` |
| [`ebda1da2`](https://github.com/NixOS/nixpkgs/commit/ebda1da2cf4de69c1878c3d3a6f8efbcde4e2932) | `frei0r-plugins: 1.6.1 -> 1.7.0`                                      | `2021-09-01 20:56:42Z` |
| [`8ee160c2`](https://github.com/NixOS/nixpkgs/commit/8ee160c2d452efc6acff0d4f286970f6f93e35ba) | `babashka: 0.5.1 -> 0.6.0`                                            | `2021-09-01 20:36:21Z` |
| [`d4c75580`](https://github.com/NixOS/nixpkgs/commit/d4c75580c18c78bdf81810dc73aab76e10754190) | `mosquitto: 2.0.11 -> 2.0.12`                                         | `2021-09-01 20:07:27Z` |
| [`1bb91a23`](https://github.com/NixOS/nixpkgs/commit/1bb91a2329ec13d0dc3ae91b58b07287b254f35e) | `mutt: 2.1.1 -> 2.1.2`                                                | `2021-09-01 19:54:31Z` |
| [`96f02afb`](https://github.com/NixOS/nixpkgs/commit/96f02afbe58d243835c9b7da811c6bab61690ed9) | `wesnoth: fix license information`                                    | `2021-09-01 19:49:06Z` |
| [`bbf089df`](https://github.com/NixOS/nixpkgs/commit/bbf089dfb7e5e99a571647bf29734f3f7babdec7) | `wesnoth: 1.4.16 -> 1.4.17`                                           | `2021-09-01 19:44:21Z` |
| [`49a231ce`](https://github.com/NixOS/nixpkgs/commit/49a231cec776bc9166226f628658d151b8855799) | `python3Packages.angrop: 9.0.9572 -> 9.0.9684`                        | `2021-09-01 18:56:11Z` |
| [`e97dfd62`](https://github.com/NixOS/nixpkgs/commit/e97dfd629a5b5a749814b20aa64781b900005399) | `python3Packages.angr: 9.0.9572 -> 9.0.9684`                          | `2021-09-01 18:56:08Z` |
| [`7402e79b`](https://github.com/NixOS/nixpkgs/commit/7402e79b0aa3255f0f6bb68f68209f5a21699b59) | `python3Packages.cle: 9.0.9572 -> 9.0.9684`                           | `2021-09-01 18:56:04Z` |
| [`13a4868e`](https://github.com/NixOS/nixpkgs/commit/13a4868e86e39edf7be8f4a39322ad4e85aed78a) | `python3Packages.claripy: 9.0.9572 -> 9.0.9684`                       | `2021-09-01 18:56:01Z` |
| [`7fb0c124`](https://github.com/NixOS/nixpkgs/commit/7fb0c12444604ea26a347b612d907c355207f829) | `python3Packages.pyvex: 9.0.9572 -> 9.0.9684`                         | `2021-09-01 18:55:58Z` |
| [`40b00086`](https://github.com/NixOS/nixpkgs/commit/40b0008639bf37ba01528c5fd86dd5ab8b726979) | `python3Packages.ailment: 9.0.9572 -> 9.0.9684`                       | `2021-09-01 18:55:55Z` |
| [`84bbe656`](https://github.com/NixOS/nixpkgs/commit/84bbe65656960c8231486c933090ba191987d714) | `python3Packages.archinfo: 9.0.9572 -> 9.0.9684`                      | `2021-09-01 18:55:52Z` |
| [`05889803`](https://github.com/NixOS/nixpkgs/commit/0588980396372a33c4a5ba83ef7432fbff50f3aa) | `yarn-bash-completion: init at 0.17.0`                                | `2021-09-01 18:35:03Z` |
| [`d37ed0e5`](https://github.com/NixOS/nixpkgs/commit/d37ed0e5ada27a5712508b81e4cf0b63759bcaae) | `neovim: remove redundant -n in test`                                 | `2021-09-01 18:21:43Z` |
| [`ba0b032b`](https://github.com/NixOS/nixpkgs/commit/ba0b032ba86bee76620735b8ff187c846fabf832) | `chatty: init at 0.3.2`                                               | `2021-09-01 16:28:30Z` |
| [`1bf2bb24`](https://github.com/NixOS/nixpkgs/commit/1bf2bb240d3566bfeda1805a02a3c85eca27c557) | `pidgin: add passthru.makePluginPath`                                 | `2021-09-01 16:27:20Z` |
| [`f8acdc76`](https://github.com/NixOS/nixpkgs/commit/f8acdc76e2826462f80533b43ebcd7d8571de932) | `perlPackages.SyntaxKeywordTry: init at 0.25`                         | `2021-09-01 15:33:33Z` |
| [`1ea4c8dc`](https://github.com/NixOS/nixpkgs/commit/1ea4c8dc31aabdd20b77a3649573cc4cbab999f2) | `exploitdb: 2021-08-28 -> 2021-09-01`                                 | `2021-09-01 13:35:02Z` |
| [`9e507a93`](https://github.com/NixOS/nixpkgs/commit/9e507a93148613753b87bf00b39d7bf218355170) | `clfswm: support custom package`                                      | `2021-09-01 13:27:37Z` |
| [`080b1486`](https://github.com/NixOS/nixpkgs/commit/080b1486041d214754cf25f4f1e94e05cba36184) | `palemoon: 29.4.0.1 -> 29.4.0.2`                                      | `2021-09-01 13:08:14Z` |
| [`6aaccdcb`](https://github.com/NixOS/nixpkgs/commit/6aaccdcbc854e107da21e8766426e4d8ba8ef8be) | `nixos/nvidia: remove extra space`                                    | `2021-09-01 12:57:33Z` |
| [`db0560c0`](https://github.com/NixOS/nixpkgs/commit/db0560c0f2a700d39528c44e84c6c6ca8be0857e) | `nixos/nvidia: fix missing variable reference`                        | `2021-09-01 12:54:32Z` |
| [`6cc260cf`](https://github.com/NixOS/nixpkgs/commit/6cc260cfd60f094500b79e279069b499806bf6d8) | `Partially revert "gnome.baobab: use strictDeps"`                     | `2021-09-01 12:52:41Z` |
| [`aff25d4c`](https://github.com/NixOS/nixpkgs/commit/aff25d4cf0b0461cd2fc7790518593984822cb6c) | `nodejs-14_x: 14.17.5 -> 14.17.6`                                     | `2021-09-01 12:37:51Z` |
| [`00fa834e`](https://github.com/NixOS/nixpkgs/commit/00fa834e558bca1feeedae4ec9b6cd55bfe4281d) | `nodejs-12_x: 12.22.5 -> 12.22.6`                                     | `2021-09-01 12:37:23Z` |
| [`7458f66f`](https://github.com/NixOS/nixpkgs/commit/7458f66f63efe11eb7616e9c15bac2595434025f) | `fstar: 2021.07.31 -> 2021.08.27 (#136215)`                           | `2021-09-01 12:31:20Z` |
| [`6f1a319c`](https://github.com/NixOS/nixpkgs/commit/6f1a319c4567d1c4273f38949ba65586585f2144) | `haskell.compiler.ghc921: mark as broken on darwin`                   | `2021-09-01 12:22:49Z` |
| [`d04f44f7`](https://github.com/NixOS/nixpkgs/commit/d04f44f7e8d6f475e91e5539becf156676caff5c) | `chromium: 92.0.4515.159 -> 93.0.4577.63`                             | `2021-09-01 11:53:00Z` |
| [`93ba1f2f`](https://github.com/NixOS/nixpkgs/commit/93ba1f2fee84bf286c5ced360c635e7052affc75) | `xfig: 3.2.8a -> 3.2.8b (#136366)`                                    | `2021-09-01 11:19:09Z` |
| [`ed48b359`](https://github.com/NixOS/nixpkgs/commit/ed48b359914cbc2b39c213b4814030125ef6d8e4) | `pick: 2.0.2 -> 4.0.0 (#136348)`                                      | `2021-09-01 08:51:55Z` |