### PR TITLE
fix: remove spammy PR linkage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ inputs:
     required: false
     description: "Print the generated Markdown table to the console"
     default: "false"
-  list-type:
-    required: false
-    description: 'The kind of HTML list to generate for associated pull requests; valid values are "ol" and "ul"'
-    default: "ul"
 ```
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -26,10 +26,6 @@ inputs:
     required: false
     description: "Print the generated Markdown table to the console"
     default: "false"
-  list-type:
-    required: false
-    description: 'The kind of HTML list to generate for associated pull requests; valid values are "ol" and "ul"'
-    default: "ul"
 outputs:
   differences:
     description: "A markdown formatted table of differences between two commits"


### PR DESCRIPTION
PR linkage is spammy, get rid of the field for now

BREAKING CHANGE: PR linkage and associated field (`list-type`) were removed
