### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c678e050c1978110badd975274785265fc953a66",
-        "sha256": "1lxra4sc8ldk8s6wlx35l5n0i8aqcqsdj42m3hns051rqbmyn7zl",
+        "rev": "6e4c36b3f7ec1400bd92ef42567b687f20f3c3c4",
+        "sha256": "0jq8715g4f8ccmk18df0m0mmq2fdnivaxhx4x61cmkyjps31f868",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/c678e050c1978110badd975274785265fc953a66.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6e4c36b3f7ec1400bd92ef42567b687f20f3c3c4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`000748c8`](https://github.com/NixOS/nixpkgs/commit/000748c82417592b55b8fa7b9421624a815b7dc6) | `miranda: add meta.mainProgram`                                                           |
| [`001598d4`](https://github.com/NixOS/nixpkgs/commit/001598d43431dd79c235b4f65dfdc971e38030ac) | `python38Packages.elasticsearch: Revert updates >7.13.1`                                  |
| [`081fe56a`](https://github.com/NixOS/nixpkgs/commit/081fe56ae46b259b1e8b5fdfb72ce6a5fe170d86) | `nodePackages.hyperpotamus: init (#132813)`                                               |
| [`cb2023cd`](https://github.com/NixOS/nixpkgs/commit/cb2023cde0474b2b243406f674ae8c7d306f2d6e) | `maintainers.openstack: fix typo in members`                                              |
| [`81b4ca7f`](https://github.com/NixOS/nixpkgs/commit/81b4ca7fc397af4c93919d88b2388c606b081407) | `maintainers/teams: add openstack`                                                        |
| [`1a15ce80`](https://github.com/NixOS/nixpkgs/commit/1a15ce8099cdbb543eaf30540ff3fbb292048af2) | `pounce: 2.4 -> 2.5`                                                                      |
| [`a432368c`](https://github.com/NixOS/nixpkgs/commit/a432368cac0ddd87af918490cdc62fee9b107681) | `python3Packages.python-miio: 0.5.7 -> 0.5.8`                                             |
| [`d73f18c2`](https://github.com/NixOS/nixpkgs/commit/d73f18c222d3a21e536448cbecd33bba8142b2c1) | `python3Packages.pre-commit: 2.14.0 -> 2.15.0`                                            |
| [`099283ce`](https://github.com/NixOS/nixpkgs/commit/099283ceca0065393ab889ac6de87b51a5ea64c9) | `vimPlugins.sqlite-lua: fix patching of sqlite3 cpath`                                    |
| [`3e10c97c`](https://github.com/NixOS/nixpkgs/commit/3e10c97c854666235d006f8417048583c98b2443) | `pythonPackages.glfw: init at 2.2.0`                                                      |
| [`c627dd26`](https://github.com/NixOS/nixpkgs/commit/c627dd26a4fa2e9f333d1e7b6e26ee675d52c707) | `python38Packages.rnc2rng: 2.6.5 -> 2.6.6`                                                |
| [`7417fada`](https://github.com/NixOS/nixpkgs/commit/7417fada6be87114832eed218e3cacb72dda8f02) | `cargo-sort: init at 1.0.5`                                                               |
| [`b99bcb5b`](https://github.com/NixOS/nixpkgs/commit/b99bcb5b9fe27a88fcfae115f9536f87902e432f) | `git-open: add SuperSandro2000 as maintainer`                                             |
| [`69e1161f`](https://github.com/NixOS/nixpkgs/commit/69e1161ff6f45ffe5ec25c61421e212bf05763ed) | `git-open: install man page`                                                              |
| [`4e6b7c37`](https://github.com/NixOS/nixpkgs/commit/4e6b7c3756b920132b4038dadd0cbe18589841c5) | `emacsPackages.isearch-prop: cosmetic rewriting`                                          |
| [`50262b51`](https://github.com/NixOS/nixpkgs/commit/50262b516fedf123cfc5b39083c55943e7b3a4c0) | `emacsPackages.git-undo: 2019-10-13 -> 0.0.0+unstable=2019-12-21`                         |
| [`06ceba58`](https://github.com/NixOS/nixpkgs/commit/06ceba58df885a6c2d92bcd3f9324247725c5101) | `emacsPackages.isearch-plus: 2021-01-01 -> 3434+unstable=2021-08-23`                      |
| [`c494e017`](https://github.com/NixOS/nixpkgs/commit/c494e01759b02cf337b330adf8b42c895fbf7ed9) | `emacsPackages.apheleia: 2021-05-23 -> 0.0.0+unstable=2021-08-08`                         |
| [`f15480cb`](https://github.com/NixOS/nixpkgs/commit/f15480cb6bb3fed3dea2a64f29497ff7398d19c0) | `python38Packages.pex: 2.1.47 -> 2.1.48`                                                  |
| [`7159fac7`](https://github.com/NixOS/nixpkgs/commit/7159fac7402e4efb362e16b0e1032418e8a71718) | `chia: 1.2.5 -> 1.2.6`                                                                    |
| [`e884717e`](https://github.com/NixOS/nixpkgs/commit/e884717edb912ca73f4a66eb1013d7e416bd3cbb) | `pythonPackages.clvm-rs: 0.1.10 -> 0.1.11`                                                |
| [`11caa13c`](https://github.com/NixOS/nixpkgs/commit/11caa13c793e52d297aa3bfdc6512a4cad3dabd9) | `pythonPackages.blspy: 1.0.5 -> 1.0.6`                                                    |
| [`432469cd`](https://github.com/NixOS/nixpkgs/commit/432469cd49fee9b2dabb7811e1262929c0b06b9a) | `python3Packages.deemix: 3.4.3 -> 3.4.4`                                                  |
| [`d6be990a`](https://github.com/NixOS/nixpkgs/commit/d6be990a2c8eeb1faa0ee49e2db7511b019d5bd2) | `python38Packages.rq: 1.9.0 -> 1.10`                                                      |
| [`bcfd1834`](https://github.com/NixOS/nixpkgs/commit/bcfd18344fe26f5e50f3503b2682ec091da6036b) | `python3Packages.deprecated: switch to pytestCheckHook`                                   |
| [`c73570b6`](https://github.com/NixOS/nixpkgs/commit/c73570b668c44f602be8e25cde07b0f1d01475d3) | `python3Packages.deprecated: 1.2.12 -> 1.2.13`                                            |
| [`6a50498b`](https://github.com/NixOS/nixpkgs/commit/6a50498b6da67f55611ab6bd3cc8c6f7048f0d08) | `linux: 5.14.1 -> 5.14.2`                                                                 |
| [`332100e6`](https://github.com/NixOS/nixpkgs/commit/332100e6e1f7e5c2326fd0f2ec54dc736fc51ae7) | `linux: 5.13.14 -> 5.13.15`                                                               |
| [`6c41ccc9`](https://github.com/NixOS/nixpkgs/commit/6c41ccc972b0e1236dc41bb85de444b524a44ff4) | `linux: 5.10.62 -> 5.10.63`                                                               |
| [`36304fc8`](https://github.com/NixOS/nixpkgs/commit/36304fc89dffe99fc1e05e2b9865fbf562d43650) | `yubikey-manager: patch path of pkill binary`                                             |
| [`7b06a14b`](https://github.com/NixOS/nixpkgs/commit/7b06a14be860f87a5a1b5a9c81e99bc13d95d70a) | `micropython: 1.15 -> 1.17`                                                               |
| [`309ed626`](https://github.com/NixOS/nixpkgs/commit/309ed626af1d5ce67ef910a28db06652a34f1f98) | `emacsPackages.sunrise-commander: 0.0.0-unstable=2021-04-23 -> 0.0.0+unstable=2021-07-22` |
| [`23b21c77`](https://github.com/NixOS/nixpkgs/commit/23b21c77f61a49178eb231e560ce95464625da02) | `nixos/release-notes: Document dry activation scripts`                                    |
| [`490081fc`](https://github.com/NixOS/nixpkgs/commit/490081fcc12f7bdae42009d6285d50df970f22dd) | `foxotron: 2021-04-19 -> 2021-08-13`                                                      |
| [`844634a0`](https://github.com/NixOS/nixpkgs/commit/844634a0d3be4de76dd013807abd9c86d5076d1a) | `kea: 1.9.10 -> 1.9.11`                                                                   |
| [`16d0899c`](https://github.com/NixOS/nixpkgs/commit/16d0899c786df7f36f22265245fca448217f3e6f) | `python3Packages.yangson: 1.4.9 -> 1.4.10`                                                |
| [`fffb00db`](https://github.com/NixOS/nixpkgs/commit/fffb00db1cdb7b3c48f85bea585d2325fa4c9400) | `legendary-gl: 0.20.6 -> 0.20.10`                                                         |
| [`a9158226`](https://github.com/NixOS/nixpkgs/commit/a91582264cdecf8327dbeb17b1b071a9463656c4) | `anytype: 0.18.59 -> 0.18.68`                                                             |
| [`5eac99e4`](https://github.com/NixOS/nixpkgs/commit/5eac99e41df880b6c3051cdf5cbaa0e35adeff42) | `python3Packages.bitlist: 0.3.1 -> 0.4.0`                                                 |
| [`831a99b3`](https://github.com/NixOS/nixpkgs/commit/831a99b32f894047a94f10d396bfc167f401f671) | `heroku: 7.51.0 -> 7.59.0`                                                                |
| [`af354d20`](https://github.com/NixOS/nixpkgs/commit/af354d20497d68d104b84d888260ca60e66c6683) | `nixos.ipfs: Fix startup after unclean shutdown.`                                         |
| [`05020744`](https://github.com/NixOS/nixpkgs/commit/05020744fbe44b7984c596190808c5a41280ba28) | `sbcl_2_1_8: init at 2.1.8`                                                               |
| [`68178096`](https://github.com/NixOS/nixpkgs/commit/68178096c65de75036508e47b965043bed33d4a1) | `libopenmpt: 0.5.10 -> 0.5.11`                                                            |
| [`b4ab817e`](https://github.com/NixOS/nixpkgs/commit/b4ab817ed08a7931cf36e247b3365fcc41b519fb) | `traefik: 2.5.1 -> 2.5.2`                                                                 |
| [`ec532944`](https://github.com/NixOS/nixpkgs/commit/ec5329444628b395817298a52192ebaaff88d40a) | `thunderbird: 91.0.3 -> 91.1.0`                                                           |
| [`706f6c57`](https://github.com/NixOS/nixpkgs/commit/706f6c57be606a5676ea3e5193e671d36182c47a) | `thunderbird-bin: 91.0.3 -> 91.1.0`                                                       |
| [`bc19f8dd`](https://github.com/NixOS/nixpkgs/commit/bc19f8dd1eaca6cb0e9af129f1b6815b1b9cffc7) | `kstars: 3.5.3 -> 3.5.4`                                                                  |
| [`3678b3d2`](https://github.com/NixOS/nixpkgs/commit/3678b3d2c77c72547dea4714c5c3afcd4389bb1c) | `stellarsolver: 1.5 -> 1.8`                                                               |
| [`18f15823`](https://github.com/NixOS/nixpkgs/commit/18f15823d23d1debb67ace6de3dbcb86aa31c99a) | `python38Packages.google-cloud-pubsub: 2.7.1 -> 2.8.0`                                    |
| [`11954703`](https://github.com/NixOS/nixpkgs/commit/11954703499dad439efa77eb4285d5d20e1e7b02) | `boops: 1.6.4 -> 1.8.2`                                                                   |
| [`44aea098`](https://github.com/NixOS/nixpkgs/commit/44aea0986baa4c6a414d24fc894c91e4623b61e9) | `hylafaxplus: 7.0.3 -> 7.0.4`                                                             |
| [`2b921548`](https://github.com/NixOS/nixpkgs/commit/2b921548788244e1738d218791461460a05de292) | `nhentai: init at 0.4.16`                                                                 |
| [`0a312a35`](https://github.com/NixOS/nixpkgs/commit/0a312a356cef625f0627174753d2dc78db415a56) | `root5: fix for gcc10`                                                                    |
| [`c89676ec`](https://github.com/NixOS/nixpkgs/commit/c89676ece37124c91301576bb6076238c77145e5) | `nncp: 6.5.0 -> 7.6.0`                                                                    |
| [`2ab79760`](https://github.com/NixOS/nixpkgs/commit/2ab79760b08f0e58d6517e210165b68ce5cdc15a) | `temporal: 1.11.4 -> 1.12.0`                                                              |
| [`789aa131`](https://github.com/NixOS/nixpkgs/commit/789aa1311642e663e8bae32041c52228260d7974) | `python3Packages.sphinx-inline-tabs: 2021.04.11.beta9 -> 2021.08.17.beta10`               |
| [`b35ade87`](https://github.com/NixOS/nixpkgs/commit/b35ade8705ca0195a6752ebbdd224125a4ee9724) | `maintainers: add travisdavis-ops`                                                        |
| [`44f32b98`](https://github.com/NixOS/nixpkgs/commit/44f32b98c28728a786a1ae3d78344b210383d37f) | `chia: don't run tests by default`                                                        |
| [`b7066a57`](https://github.com/NixOS/nixpkgs/commit/b7066a57deb8bb3f13ab7f2ef5e389c0559edac0) | `libaom: disable NEON on armv7l`                                                          |
| [`5e72b0a0`](https://github.com/NixOS/nixpkgs/commit/5e72b0a076509369f4bca28f3dffd800455299c9) | `fossil: 2.15.1 -> 2.16`                                                                  |
| [`a46e2c43`](https://github.com/NixOS/nixpkgs/commit/a46e2c439059fbf074920dab43e7af7abccd6e21) | `chia: 1.2.3 -> 1.2.5`                                                                    |
| [`1d7311d3`](https://github.com/NixOS/nixpkgs/commit/1d7311d36fbaf7f95615245ec842321c9c6e4f58) | `howard-hinnant-date: unstable-2020-03-09 -> 3.0.1`                                       |
| [`c8402f4a`](https://github.com/NixOS/nixpkgs/commit/c8402f4a61031413c964f0b1a0f5059012d0e530) | `pythonPackages.clvm-rs: 0.1.8 -> 0.1.10`                                                 |
| [`c54eb649`](https://github.com/NixOS/nixpkgs/commit/c54eb6492aba0a04b5075259e236d32095e1f687) | `pythonPackages.chiavdf: 1.0.2 -> 1.0.3`                                                  |
| [`ce6ef94b`](https://github.com/NixOS/nixpkgs/commit/ce6ef94b4c61714b8772bfc40c5559c2d3a3168c) | `senv: 0.5.0 -> 0.7.0`                                                                    |