### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46ff1961227eb9ff16875b48f4e3562497d0f0e7",
-        "sha256": "035nk778lx2dpx1spy8k8blan2768kd1px6znvxql096l5jsmqfc",
+        "rev": "ff748a82a5fff004c952f32eacd64604a6f4036f",
+        "sha256": "0a6nidbzdmywxfknqgj7hjhdsvvxncb8jkksyc49mp81d9lwk2fy",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/46ff1961227eb9ff16875b48f4e3562497d0f0e7.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ff748a82a5fff004c952f32eacd64604a6f4036f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
| [`5545104c`](https://github.com/NixOS/nixpkgs/commit/5545104ce310a43f4a23935754392bd81fa8f9f0) | `xcolor: 0.5.0 -> 0.5.1`                                                                                              |
| [`ed74ad63`](https://github.com/NixOS/nixpkgs/commit/ed74ad630c05b43b6af685a5e1eeba6136b8f04f) | `vale: 2.10.5 -> 2.10.6`                                                                                              |
| [`1628a1c7`](https://github.com/NixOS/nixpkgs/commit/1628a1c78b3cf6564c82993fe7d6cebebb8791e6) | `numberstation: 0.4.0 -> 0.5.0`                                                                                       |
| [`4e52d933`](https://github.com/NixOS/nixpkgs/commit/4e52d93305204d3ddb084d241f4d14c55bfdd404) | `emacs.pkgs.ement: Fix meta.description`                                                                              |
| [`23837756`](https://github.com/NixOS/nixpkgs/commit/23837756205f6ca8ecc1f531323d0a842572b40e) | `nextdns: 1.36.0 -> 1.37.2`                                                                                           |
| [`964b74f6`](https://github.com/NixOS/nixpkgs/commit/964b74f6b47b0ffb82d59856eaf527b3b1a8c129) | `gitui: do not compile openssl`                                                                                       |
| [`f4383bca`](https://github.com/NixOS/nixpkgs/commit/f4383bcab4eef33cfbde4b2ac8aeedfb59d6d087) | `terraformer: 0.8.15 -> 0.8.16`                                                                                       |
| [`a7f71cd4`](https://github.com/NixOS/nixpkgs/commit/a7f71cd419821adc5e3d7b9ae9e5b0f558370b28) | `emacs.pkgs.ement: init at unstable-2021-09-08`                                                                       |
| [`38a96d81`](https://github.com/NixOS/nixpkgs/commit/38a96d8148f966934f85fe222593477be8094e71) | `emacs.pkgs.plz: init at unstable-2021-08-22`                                                                         |
| [`92cc52ac`](https://github.com/NixOS/nixpkgs/commit/92cc52acb8c05609978769edd94772ffa9dba4a1) | `pyradio: 0.8.7.2 -> 0.8.9.9`                                                                                         |
| [`0c31bd3d`](https://github.com/NixOS/nixpkgs/commit/0c31bd3d4efda50128ffedfe1daaceeaf90d5763) | `yq-go: 4.12.1 -> 4.12.2`                                                                                             |
| [`a5d5f32f`](https://github.com/NixOS/nixpkgs/commit/a5d5f32f9018fcafb203437740964ab574aef8ab) | `csvs-to-sqlite: added override for `click` dependency to version `7` in order to fix build`                          |
| [`e676fdcb`](https://github.com/NixOS/nixpkgs/commit/e676fdcb901455956acd04e58e88dd777871f73e) | `picard-tools: 2.26.0 -> 2.26.2`                                                                                      |
| [`6957f6cb`](https://github.com/NixOS/nixpkgs/commit/6957f6cb1efd2a3b9b85683bd2b3cae6c0b1068c) | `python3Packages.google-resumable-media: fix google-crc32c bounds`                                                    |
| [`afc91f5f`](https://github.com/NixOS/nixpkgs/commit/afc91f5fefe5d159001238feb56c3267f65357c5) | `graphite2: fixup build on aarch64-darwin after PR #123420`                                                           |
| [`d5c8c843`](https://github.com/NixOS/nixpkgs/commit/d5c8c84384fe710727b1be0fbb1ef7572aadd97e) | `qbittorrent: 4.3.5 -> 4.3.8`                                                                                         |
| [`b62c799d`](https://github.com/NixOS/nixpkgs/commit/b62c799d04d89f9ac9002cfd3886ce919a056a5c) | `ajour: 1.3.0 -> 1.3.1`                                                                                               |
| [`7bea76e0`](https://github.com/NixOS/nixpkgs/commit/7bea76e0d219c6ca81677cfa318927628fd70263) | `nats-server: 2.4.0 -> 2.5.0`                                                                                         |
| [`92042a28`](https://github.com/NixOS/nixpkgs/commit/92042a285e45c40936a3813b95f2e1079a51ecf9) | `python3Packages.jupyter-server: 1.10.2 -> 1.11.0, fix build and tests`                                               |
| [`60ab0ab2`](https://github.com/NixOS/nixpkgs/commit/60ab0ab2db14e405ac6f019229b88ca4ff3e8883) | `devpi-server: 6.0.0.dev0 -> 6.2.0, override pyramid version`                                                         |
| [`ac74b423`](https://github.com/NixOS/nixpkgs/commit/ac74b42351e671d45949341fe5b9dac5bb69f574) | `csvs-to-sqlite: removed from `python-package` since it's an command line application`                                |
| [`f7978d72`](https://github.com/NixOS/nixpkgs/commit/f7978d726a881a6911a596b19d246604ad8bab75) | `exploitdb: 20221-09-10 -> 2021-09-14`                                                                                |
| [`54cca755`](https://github.com/NixOS/nixpkgs/commit/54cca75528fafcd8a45413b1323820c9128d01ef) | `python39Packages.cliff: fix missing dependency, tests and adopt to openstack team`                                   |
| [`01bd54a0`](https://github.com/NixOS/nixpkgs/commit/01bd54a0aa3f4f6ca23efbe0a9592fe578eefe16) | `python3Packages: rename passthru test for openstack team`                                                            |
| [`09def9cc`](https://github.com/NixOS/nixpkgs/commit/09def9cc2fccd6aca204a4f034be32437d4b262a) | `nomino: init at 1.1.0`                                                                                               |
| [`f3fba3c3`](https://github.com/NixOS/nixpkgs/commit/f3fba3c3361ef0c03180af77852ba60ab501e2cc) | `azure-cli/azure-cli-core: update requests substitution`                                                              |
| [`28b6a910`](https://github.com/NixOS/nixpkgs/commit/28b6a91047e796b1578120342701dcb89838e4ed) | `libssh2: temporarily add separate 1.10.0`                                                                            |
| [`6b48a031`](https://github.com/NixOS/nixpkgs/commit/6b48a031d9cc47356b4e7e3e2cb8967446890261) | `fcl: 0.6.1 -> 0.7.0`                                                                                                 |
| [`bd6c0565`](https://github.com/NixOS/nixpkgs/commit/bd6c0565b2947c58d951046ecfd4718489c9b515) | `python39Packages.pbr: enable tests, adopt into openstack team`                                                       |
| [`1efdeb87`](https://github.com/NixOS/nixpkgs/commit/1efdeb8767c60816a3fbf5c7cdd9f8e3e159f5e9) | `python39Packages.autopage: init at 0.4.0`                                                                            |
| [`ce79b669`](https://github.com/NixOS/nixpkgs/commit/ce79b66953e4c7932f5c43b70181829f58c96598) | `git-interactive-rebase-tool: fix compile error`                                                                      |
| [`a4cdaede`](https://github.com/NixOS/nixpkgs/commit/a4cdaede17bea1339c4e607931fa938b8148a56c) | `python39Packages.gcovr: add missing dependency`                                                                      |
| [`9177f704`](https://github.com/NixOS/nixpkgs/commit/9177f704bd01568f975f7ca18e2d2595a3ffe9ca) | `chia: relax all version constraints`                                                                                 |
| [`1b5b70a3`](https://github.com/NixOS/nixpkgs/commit/1b5b70a373790fc2aa0b3afe640ad336bfae07ad) | `python39Packages.pyramid_mako: mark broken`                                                                          |
| [`01ab36d8`](https://github.com/NixOS/nixpkgs/commit/01ab36d8752c2efe901136f19c18ea309b995ac0) | `mariadb.client: fixup build`                                                                                         |
| [`b6416616`](https://github.com/NixOS/nixpkgs/commit/b6416616b2646561ca80b2d95398b322e53fb611) | `zoxide: 0.7.4 -> 0.7.5`                                                                                              |
| [`a8be3a74`](https://github.com/NixOS/nixpkgs/commit/a8be3a74ccafe990aeb59f51fabd22b77f7c416d) | `cmake: revert cmake support for 10.4 Tiger`                                                                          |
| [`96eb6ec4`](https://github.com/NixOS/nixpkgs/commit/96eb6ec434cead2d6627308a61e1d2e3127dcd8e) | `streamlink: 2.3.0 -> 2.4.0`                                                                                          |
| [`daa11752`](https://github.com/NixOS/nixpkgs/commit/daa1175255391663ee97d1dd0940d7a7eb5c0078) | `cmake: 3.21.1 -> 3.21.2`                                                                                             |
| [`b4435704`](https://github.com/NixOS/nixpkgs/commit/b44357045a1257a9be6e153a728597c61d9f7341) | `python3Packages.agate-excel: add missing olefile dep`                                                                |
| [`fc77b402`](https://github.com/NixOS/nixpkgs/commit/fc77b402c066a3ae201631db74bb5d8196df13fd) | `conan: 1.35.0 -> 1.40.0`                                                                                             |
| [`87a72a58`](https://github.com/NixOS/nixpkgs/commit/87a72a58b707822ae2a0ae15c776c87a3e9f487e) | `python3Packages.lexid: disable lib3to6 usage to fix build`                                                           |
| [`83d16774`](https://github.com/NixOS/nixpkgs/commit/83d16774f2fc8db795926f1d3cf58b2bf6700fab) | `awscli2: add older awscrt to make build work`                                                                        |
| [`222c5477`](https://github.com/NixOS/nixpkgs/commit/222c5477e205a7c2f68ba96a656851d52281a720) | `python3Packages.pythran: use LLVM openmp when using clang`                                                           |
| [`455ef767`](https://github.com/NixOS/nixpkgs/commit/455ef76700ca1b703879cef66333d7e9d4bebba7) | `matrix-synapse: use frozendict 1.2`                                                                                  |
| [`6da8f606`](https://github.com/NixOS/nixpkgs/commit/6da8f606837b9c51e185f5753babc44b98630a8c) | `aws-sam-cli: further loosen 'requests' dependency`                                                                   |
| [`b3800220`](https://github.com/NixOS/nixpkgs/commit/b3800220258053131be289f6225d2bb8561a7f9d) | `python3Packages.backports-functools-lru-cache: use backports namespace`                                              |
| [`02633095`](https://github.com/NixOS/nixpkgs/commit/02633095e3c292cedf8ea35a3e55cbd2cbd4cb37) | `python3Packages.backports-entry-points-selectable: use backports namespace`                                          |
| [`554d86af`](https://github.com/NixOS/nixpkgs/commit/554d86af2039b1b6dbd6c7b3eb969b2bc5d54580) | `openjfx11: fix build`                                                                                                |
| [`b9135680`](https://github.com/NixOS/nixpkgs/commit/b913568092d28651b7feb6f3f56cabe2279187c9) | `linux_5_13_hardened: port to linux-kernels.nix`                                                                      |
| [`90354922`](https://github.com/NixOS/nixpkgs/commit/90354922c244e17dd35b110fa9d5d1083fd18819) | `nixos/doc: adjust to the new structure of kernel packages`                                                           |
| [`a6079f83`](https://github.com/NixOS/nixpkgs/commit/a6079f83313cd26fc6f6c5d8dd0922a278fafd8d) | `metals: 0.10.5 -> 0.10.6`                                                                                            |
| [`42155910`](https://github.com/NixOS/nixpkgs/commit/42155910a0a499e9cc937ae89f022fcd5b551cf6) | `pkgsStatic.curl: fix build`                                                                                          |
| [`4e1b102a`](https://github.com/NixOS/nixpkgs/commit/4e1b102af618fc3e8da11da8a0cea28e5c104f3a) | `curl: reenable ca-fallback when not using wolfsslSupport`                                                            |
| [`53b78c1a`](https://github.com/NixOS/nixpkgs/commit/53b78c1a641964d54850f427bcd19fa0935400b5) | `ocamlPackages.cryptokit: fix output dest dir`                                                                        |
| [`3a5fc1aa`](https://github.com/NixOS/nixpkgs/commit/3a5fc1aad414f2de7813cec48d25e73aa553c0bb) | `ocamlPackages.camomile: fix output dest dir`                                                                         |
| [`6310613b`](https://github.com/NixOS/nixpkgs/commit/6310613bb00ff433b53908f859a06aee4b7f07ba) | `ocamlPackages.ocaml_oasis: fix build`                                                                                |
| [`125c7a4e`](https://github.com/NixOS/nixpkgs/commit/125c7a4ef53def6ffb1a06852e47a64a796e5577) | `ocamlPackages.erm_xmpp: fix build`                                                                                   |
| [`590471d1`](https://github.com/NixOS/nixpkgs/commit/590471d1772e0045e93097c19f955d919350c06c) | `ocamlPackages.extlib: fix build`                                                                                     |
| [`6073831a`](https://github.com/NixOS/nixpkgs/commit/6073831a11510127a41ff2478abd799f0965e2f4) | `imake: do not skip Linux* vendor definitions`                                                                        |
| [`79031203`](https://github.com/NixOS/nixpkgs/commit/79031203b88f8b96b1321416f59e23481cceed45) | `xvkbd: explicitly set LIBDIR and CONFDIR`                                                                            |
| [`bace74bb`](https://github.com/NixOS/nixpkgs/commit/bace74bbf8e9bac15802c5382d7e46fd26be72ba) | `xcruiser: explicitly set LIBDIR and CONFDIR`                                                                         |
| [`1333bd9a`](https://github.com/NixOS/nixpkgs/commit/1333bd9ac04fa4be2050b356bd2906a882b716ca) | `xxkb: explicitly set LIBDIR and CONFDIR`                                                                             |
| [`01009697`](https://github.com/NixOS/nixpkgs/commit/010096974f03009d221b533dd5c16c3d8b794ba1) | `icewm: fix trailing -I compilation errors`                                                                           |
| [`4cc9b841`](https://github.com/NixOS/nixpkgs/commit/4cc9b841182fe88ece2d33a77e6937458a0f9fa9) | `python3Packages.requests: 2.25.1 -> 2.26.0`                                                                          |
| [`5e3cb009`](https://github.com/NixOS/nixpkgs/commit/5e3cb00953c6f46d3ffdd9e4550f7744ad4010cc) | `python3Packages.charset-normalizer: init at 2.0.1`                                                                   |
| [`7f732aca`](https://github.com/NixOS/nixpkgs/commit/7f732aca66089969ca0733bd129cc1c12b44fe25) | `Revert "Merge remote-tracking branch 'origin/python-unstable' into staging-next"`                                    |
| [`ab7c78ff`](https://github.com/NixOS/nixpkgs/commit/ab7c78ff9cb015b3388dab2ca967aded891201be) | `python3Packages.hdbscan: add imports check`                                                                          |
| [`7c2893ed`](https://github.com/NixOS/nixpkgs/commit/7c2893ed098c0be4ffe85648548df7b4155b2aea) | `calibre-web: relax requests constraints`                                                                             |
| [`0a88fd9b`](https://github.com/NixOS/nixpkgs/commit/0a88fd9bdbd87a0ce7a32ff4cf200030f443e53f) | `python3Packages.python-daemon: fix build & refactor`                                                                 |
| [`6b0b9774`](https://github.com/NixOS/nixpkgs/commit/6b0b9774e2401aba3e82ebba89a9f2b9e0002e0d) | `snscrape: 0.3.4 -> unstable-2021-08-30`                                                                              |
| [`7c4c6133`](https://github.com/NixOS/nixpkgs/commit/7c4c61335c4e7ce50e45de2b45a7c41dc553e8dd) | `python3Packages.quantities: fix build`                                                                               |
| [`e9120ab7`](https://github.com/NixOS/nixpkgs/commit/e9120ab7773f8483ab41de5c48263db25665e984) | `python3Packages.screeninfo: fix build`                                                                               |
| [`8c41a03a`](https://github.com/NixOS/nixpkgs/commit/8c41a03a2d851b08b801a85c16b3774e0079bc8c) | `python3Packages.executing: fix build`                                                                                |
| [`f140e5b2`](https://github.com/NixOS/nixpkgs/commit/f140e5b2bf8994548cd660fda9dd5a176fd806b2) | `python3Packages.k5test: fix build`                                                                                   |
| [`7f7b3f67`](https://github.com/NixOS/nixpkgs/commit/7f7b3f67c18e9331f304f05a07a96919494ac9f8) | `python3Packages.asttokens: 2.0.4 -> 2.0.5`                                                                           |
| [`0c7822c7`](https://github.com/NixOS/nixpkgs/commit/0c7822c7e76127e4fc55f011fe4fff74017c5d32) | `python3Packages.acoustics: fix build`                                                                                |
| [`80d7fafa`](https://github.com/NixOS/nixpkgs/commit/80d7fafa0eb62d209645010f4f589b6611a5a587) | `python3Packages.acme-tiny: fix build`                                                                                |
| [`b68026b5`](https://github.com/NixOS/nixpkgs/commit/b68026b52be87a6aeb9eceec61c81b629bb95988) | `python3Packages.dask: 2021.06.2 -> 2021.08.1`                                                                        |
| [`070e765d`](https://github.com/NixOS/nixpkgs/commit/070e765d0aaa3b5e30c85130a6eb9442ac53a488) | `python3Packages.cmd2: fix build`                                                                                     |
| [`e44bb984`](https://github.com/NixOS/nixpkgs/commit/e44bb98416572a28aa5006f955cd855c606c65d6) | `bump2version: 1.0.0 -> 1.0.1`                                                                                        |
| [`0e704fa6`](https://github.com/NixOS/nixpkgs/commit/0e704fa628ad8a7a9418952bbcb0d8c1f154559a) | `python3Packages.ssdp: fix build`                                                                                     |
| [`250f619f`](https://github.com/NixOS/nixpkgs/commit/250f619f52d7c588bcd0f239869b1217ec779387) | `python3Packages.platformdirs: 2.2.0 -> 2.3.0`                                                                        |
| [`5afdc278`](https://github.com/NixOS/nixpkgs/commit/5afdc27831d68c9c0baaa92183ff9522c232f0a0) | `python3Packages.hstspreload: 2021.8.1 -> 2021.9.1`                                                                   |
| [`e673e7fa`](https://github.com/NixOS/nixpkgs/commit/e673e7fa516baee6c6309135a6e1e143a718fc06) | `python3Packages.elmax: 0.1.2 -> 0.1.3`                                                                               |
| [`c8845ea5`](https://github.com/NixOS/nixpkgs/commit/c8845ea5e9162486ed3cfef776f29ca57fddc448) | `python39Packages.fastparquet: 0.7.0 -> 0.7.1`                                                                        |
| [`37d31ecb`](https://github.com/NixOS/nixpkgs/commit/37d31ecb87e11f9a58c42a47937bd7da7f8e666d) | `caffe2: mark broken`                                                                                                 |
| [`618d441b`](https://github.com/NixOS/nixpkgs/commit/618d441bca0b479dfe92dab15d2482545d0997de) | `python39Packages.werkzeug: normalise pname`                                                                          |
| [`ebe22323`](https://github.com/NixOS/nixpkgs/commit/ebe22323830e4aac1be5b062ec8e3235375c57b0) | `python39Packages.fiona: fix tests, format, normalise pname`                                                          |
| [`df05bb46`](https://github.com/NixOS/nixpkgs/commit/df05bb468623de7c63ac9fc6e5526624f3150e5f) | `python39Packages.moviepy: relax decorator dependency, forma, remove ? null from inputs`                              |
| [`a7eb7ecb`](https://github.com/NixOS/nixpkgs/commit/a7eb7ecbe38bcba227cee1a1e5e71a831b3a09b8) | `pylode: 2.8.6 -> 2.12.0`                                                                                             |
| [`c076955f`](https://github.com/NixOS/nixpkgs/commit/c076955ffdca822d9f227b8f5da830f50d3388f7) | `python39Packages.pyocr: switch to pytestCheckHook, format, fix setuptools not finding version`                       |
| [`ff225bee`](https://github.com/NixOS/nixpkgs/commit/ff225beeae6593f7c2d3f4c4f2a63bee448d3e50) | `python39Packages.python-lsp-server: disable failing test after pylint update, format, move postPatch after src`      |
| [`6711517e`](https://github.com/NixOS/nixpkgs/commit/6711517eea8e1bd0165b7f4916309888c5ee8dcb) | `python39Packages.rdflib-jsonld: mark broken`                                                                         |
| [`229cd3e5`](https://github.com/NixOS/nixpkgs/commit/229cd3e58db39afdeee567d980ad7efca23ce7d7) | `python39Packages.dateutils: init at 0.6.12`                                                                          |
| [`d779e6d2`](https://github.com/NixOS/nixpkgs/commit/d779e6d217591bbaceff1f643a49d55ee12d8703) | `python39Packages.ibm-cloud-sdk-core: disable failing tests, remove linting and not required checkInputs`             |
| [`acf4f5f2`](https://github.com/NixOS/nixpkgs/commit/acf4f5f2bab5272240e4c8240100936bdf1b5875) | `python39Packages.canonicaljson: execute tests with pytestCheckHook, disable failing test`                            |
| [`fe734dd3`](https://github.com/NixOS/nixpkgs/commit/fe734dd3bb5ab8e5b48ae1b70389c9c2ebc3e0a2) | `kupfer: no longer use python36Packages`                                                                              |
| [`f1691206`](https://github.com/NixOS/nixpkgs/commit/f1691206f62407bb3482fcc4724c838b27a9f36d) | `python3Packages.mocket: 3.9.42 -> 3.9.44`                                                                            |
| [`e2ec8b85`](https://github.com/NixOS/nixpkgs/commit/e2ec8b85bfc006a15175206194efdf856a84105f) | `python3Packages.freetype-py: enable tests`                                                                           |
| [`1bec8b29`](https://github.com/NixOS/nixpkgs/commit/1bec8b29ac9ab1e8229f8124d0b25299ec1fa6e5) | `python3Packages.pyTelegramBotAPI: 3.8.3 -> 4.0.0`                                                                    |
| [`aa4e252c`](https://github.com/NixOS/nixpkgs/commit/aa4e252cd2c514e443e911c8babe59571b673769) | `python3Packages.pydeconz: 82 -> 83`                                                                                  |
| [`18db4c3f`](https://github.com/NixOS/nixpkgs/commit/18db4c3f33e459d1a876a56512517a400b67d077) | `python3Packages.zarr: 2.9.3 -> 2.9.4`                                                                                |
| [`e337b46f`](https://github.com/NixOS/nixpkgs/commit/e337b46f5c3293dc612ba4056eabdbb2b2ace181) | `python3Packages.vispy: 0.8.0 -> 0.8.1`                                                                               |
| [`f23b0af2`](https://github.com/NixOS/nixpkgs/commit/f23b0af2bd6e0902835b7855d61bd2e715af1a88) | `python3Packages.typing_extensions: 3.10.0.0 -> 3.10.0.2`                                                             |
| [`1e5d3eba`](https://github.com/NixOS/nixpkgs/commit/1e5d3eba8b68387e9b72384c0df7a9f6e931a5f4) | `python3Packages.traitlets: 5.0.5 -> 5.1.0`                                                                           |
| [`b22a0a35`](https://github.com/NixOS/nixpkgs/commit/b22a0a359a2993ebe5f7b51223a5521c0a214ce9) | `python3Packages.snowflake-connector-python: 2.5.1 -> 2.6.0`                                                          |
| [`9cb1a529`](https://github.com/NixOS/nixpkgs/commit/9cb1a529d3f522a98d063a4e1cd8ecca2f7bc7c0) | `python3Packages.smart-open: 5.2.0 -> 5.2.1`                                                                          |
| [`ac59950e`](https://github.com/NixOS/nixpkgs/commit/ac59950efd536c206620491d10cbe9335fb5da7f) | `python3Packages.sagemaker: 2.56.0 -> 2.57.0`                                                                         |
| [`21d8d444`](https://github.com/NixOS/nixpkgs/commit/21d8d4442bf0c949e817a99b4cd61e6c4d5a6395) | `python3Packages.ruamel.yaml: 0.17.14 -> 0.17.16`                                                                     |
| [`829d1a42`](https://github.com/NixOS/nixpkgs/commit/829d1a42ee2dabcfade856941321f79f46b5e384) | `python3Packages.ROPGadget: 6.5 -> 6.6`                                                                               |
| [`30a1373f`](https://github.com/NixOS/nixpkgs/commit/30a1373f5fa32c83c47f757de83f92fcb6dd229c) | `python3Packages.rich: 10.7.0 -> 10.9.0`                                                                              |
| [`ca807c74`](https://github.com/NixOS/nixpkgs/commit/ca807c744eccbf2ec6f7450126ed108c5b104a53) | `python3Packages.regex: 2021.8.21 -> 2021.8.28`                                                                       |
| [`ca857ce0`](https://github.com/NixOS/nixpkgs/commit/ca857ce04231048e3e98e87b7d6e27e9d17efdd4) | `python3Packages.pytube: 11.0.0 -> 11.0.1`                                                                            |
| [`37fa6363`](https://github.com/NixOS/nixpkgs/commit/37fa636325c475b9a26d248c240674f8f611c985) | `python3Packages.python-gitlab: 2.10.0 -> 2.10.1`                                                                     |
| [`6bb29572`](https://github.com/NixOS/nixpkgs/commit/6bb29572e4dc9410401bd6b6d166549be8427c78) | `python3Packages.pytest: 6.2.4 -> 6.2.5`                                                                              |
| [`9965898a`](https://github.com/NixOS/nixpkgs/commit/9965898a66e3c7b9e53b0fd66ee33b7371ddde2f) | `python3Packages.pyfakefs: 4.5.0 -> 4.5.1`                                                                            |
| [`a7a05434`](https://github.com/NixOS/nixpkgs/commit/a7a054346d3c15c77f9060323eaf636f8ef6b5f3) | `python3Packages.pyfaidx: 0.6.1 -> 0.6.2`                                                                             |
| [`e88671f3`](https://github.com/NixOS/nixpkgs/commit/e88671f3dbdee8967be7f242b29f337f9006e51d) | `python3Packages.py3status: 3.38 -> 3.39`                                                                             |
| [`d9153319`](https://github.com/NixOS/nixpkgs/commit/d91533198b733b9a4e3656003430f38f0e9d69ab) | `python3Packages.prettytable: 2.1.0 -> 2.2.0`                                                                         |
| [`d89e0a4f`](https://github.com/NixOS/nixpkgs/commit/d89e0a4f77b46a8fea435276a5124378c16b788d) | `python3Packages.plotly: 5.2.2 -> 5.3.0`                                                                              |
| [`98ec450f`](https://github.com/NixOS/nixpkgs/commit/98ec450fc88b220edf91314c1f061eb0091c44b7) | `python3Packages.plaid-python: 8.0.0 -> 8.1.0`                                                                        |
| [`c8911ada`](https://github.com/NixOS/nixpkgs/commit/c8911ada308f302035cdf95bc50b014c82476840) | `python3Packages.mne-python: 0.23.2 -> 0.23.3`                                                                        |
| [`cfe33679`](https://github.com/NixOS/nixpkgs/commit/cfe336796f6ef0a5f2a9e53a11cd21e9fe7b9f62) | `python3Packages.minidump: 0.0.18 -> 0.0.19`                                                                          |
| [`ae0d5b48`](https://github.com/NixOS/nixpkgs/commit/ae0d5b484a67f61be67d1232e64772a57f9ee70a) | `python3Packages.mautrix: 0.10.5 -> 0.10.6`                                                                           |
| [`9305faf3`](https://github.com/NixOS/nixpkgs/commit/9305faf3578c64e918d38dcb64fe84dd9ff90175) | `python3Packages.labelbox: 3.1.0 -> 3.2.0`                                                                            |
| [`c9436194`](https://github.com/NixOS/nixpkgs/commit/c9436194e033acbe620745e6ac923eaf940f9971) | `python3Packages.kiwisolver: 1.3.1 -> 1.3.2`                                                                          |
| [`d229c023`](https://github.com/NixOS/nixpkgs/commit/d229c023d25ed7a358352ca94e8ad0a04d91eb11) | `python3Packages.jupyter_client: 7.0.1 -> 7.0.2`                                                                      |
| [`f2ed073a`](https://github.com/NixOS/nixpkgs/commit/f2ed073a9056488b5e49d8b925386d5dee5135ff) | `python3Packages.ipython: 7.26.0 -> 7.27.0`                                                                           |
| [`cc5eb107`](https://github.com/NixOS/nixpkgs/commit/cc5eb10728edea389531b546425e69c3f4ca6404) | `python3Packages.ipykernel: 6.2.0 -> 6.3.0`                                                                           |
| [`dd93840f`](https://github.com/NixOS/nixpkgs/commit/dd93840fa1235deaacc299a1605531edfd7e4df5) | `python3Packages.hypothesis: 6.15.0 -> 6.17.3`                                                                        |
| [`77565e3c`](https://github.com/NixOS/nixpkgs/commit/77565e3cee2b6ff56174ad5574cf27b6dad743d5) | `python3Packages.gradient: 1.7.2 -> 1.7.4`                                                                            |
| [`c7d731da`](https://github.com/NixOS/nixpkgs/commit/c7d731dab39f7870d532e81f284bd2eaf66c1bd4) | `python3Packages.google-crc32c: 1.1.2 -> 1.1.3`                                                                       |
| [`5ef52dd2`](https://github.com/NixOS/nixpkgs/commit/5ef52dd2ade9c8cc16598df17c389c5478ca2c1f) | `python3Packages.google-cloud-testutils: 1.0.0 -> 1.1.0`                                                              |
| [`c08755eb`](https://github.com/NixOS/nixpkgs/commit/c08755eb0e3ba5db6628e8f2e4ff3390715065b0) | `python3Packages.google-cloud-bigquery-datatransfer: 3.3.1 -> 3.3.2`                                                  |
| [`6b968870`](https://github.com/NixOS/nixpkgs/commit/6b96887023528dec6df11e12aa19091756be15be) | `python3Packages.dpkt: 1.9.7.1 -> 1.9.7.2`                                                                            |
| [`d5be3068`](https://github.com/NixOS/nixpkgs/commit/d5be30682299bd94b0852e9f11ff184bfa264058) | `python3Packages.django-environ: 0.4.5 -> 0.5.0`                                                                      |
| [`78503c40`](https://github.com/NixOS/nixpkgs/commit/78503c4085759871735e77609eebe9aa9d3ef6bc) | `python3Packages.commoncode: 21.7.23 -> 21.8.27`                                                                      |
| [`94bddb0b`](https://github.com/NixOS/nixpkgs/commit/94bddb0b85a5fa6783f8e7bafbbcd0d9b61684eb) | `python3Packages.chart-studio: 5.2.2 -> 5.3.0`                                                                        |
| [`832b2ae3`](https://github.com/NixOS/nixpkgs/commit/832b2ae368e5bd982813bae01e6d11aebb16ab58) | `python3Packages.cfn-lint: 0.53.0 -> 0.53.1`                                                                          |
| [`75534368`](https://github.com/NixOS/nixpkgs/commit/755343688c17eba3687863684752ae7919b13905) | `python3Packages.casbin: 1.5.0 -> 1.7.0`                                                                              |
| [`92571ee8`](https://github.com/NixOS/nixpkgs/commit/92571ee890fe2368a41b3ade877f46c55f962199) | `python3Packages.astroid: 2.7.2 -> 2.7.3`                                                                             |
| [`43c225d3`](https://github.com/NixOS/nixpkgs/commit/43c225d3ce7dd1a1e1e1d22cf06f83e87514fd79) | `python3Packages.alembic: 1.6.5 -> 1.7.1`                                                                             |
| [`b85ee268`](https://github.com/NixOS/nixpkgs/commit/b85ee268e1cbebe49cb9fa29358c326b1bbff3a8) | `python3Packages.pyosmium: add requests dependency`                                                                   |
| [`e7477887`](https://github.com/NixOS/nixpkgs/commit/e7477887aee8bd0e84ecfe7d6e0f092e45c48daa) | `python3Packages.pytest-doctestplus: disable failing tests, update deps`                                              |
| [`a81561f9`](https://github.com/NixOS/nixpkgs/commit/a81561f9f7d6b488e313d1ba504e9ee0297b7deb) | `python3Packages.geoalchemy2: fix build, enable tests, refactor`                                                      |
| [`495a9649`](https://github.com/NixOS/nixpkgs/commit/495a9649e623cb06fdd2da5030ebb0107fcdbf24) | `python3Packages.mocket: relax decorator constraint`                                                                  |
| [`f777eddf`](https://github.com/NixOS/nixpkgs/commit/f777eddfce128d6851863db16ce4a7f55ec4d790) | `plover.dev: 4.0.0.dev8 -> 4.0.0.dev10`                                                                               |
| [`6b29e13f`](https://github.com/NixOS/nixpkgs/commit/6b29e13f36b95445fced271f93f43088c3647c89) | `appgate-sdp: use python3Packages instead of python37Packages`                                                        |
| [`191e88df`](https://github.com/NixOS/nixpkgs/commit/191e88dfbdfb82ad4db6596ee1f1686b6a6a6543) | `criterion: use python3Packages instead of python37Packages`                                                          |
| [`84f13d40`](https://github.com/NixOS/nixpkgs/commit/84f13d408f8bbfa2bcf191a6b0f6362c7a773b05) | `boxfort: use python3Packages instead of python37Packages`                                                            |
| [`081a0fa2`](https://github.com/NixOS/nixpkgs/commit/081a0fa2023f13890ddf20eabd9a2fb5e4dae515) | `variety: use python3Packages instead of python37Packages`                                                            |
| [`5253aa55`](https://github.com/NixOS/nixpkgs/commit/5253aa553cb7ab324512e1bc6a5e8b1c10753dc3) | `top-level: use python3Packages instead of python37Packages`                                                          |
| [`838b36e5`](https://github.com/NixOS/nixpkgs/commit/838b36e5881d0e434bad8a452b2054a6768d81ce) | `python39Packages.zconfig: 3.5.0 -> 3.6.0`                                                                            |
| [`5e2ebb59`](https://github.com/NixOS/nixpkgs/commit/5e2ebb592aa056c716f22329b03f45e424e5132f) | `vulnix: disable python3Packages overwrite`                                                                           |
| [`25c4bbf1`](https://github.com/NixOS/nixpkgs/commit/25c4bbf1efaaa24913d1ce662d63080ee54eafef) | `python39Packages.zodb: remove outdated disabled`                                                                     |
| [`c617466c`](https://github.com/NixOS/nixpkgs/commit/c617466cadc6c725b532a233d2f06b1f178d537e) | `python39Packages.sphinxcontrib-tikz: replace patch by substituteInPlace to prevent apply errors`                     |
| [`9f5cc3d5`](https://github.com/NixOS/nixpkgs/commit/9f5cc3d58bf6d0df0513a6554305f12f16418397) | `python39Packages.debugpy: throw on unsupported system`                                                               |
| [`4e285168`](https://github.com/NixOS/nixpkgs/commit/4e285168fe0e2ec9184b24c27bafdafc0e0548fc) | `platformio: remove 32bit packages to unbreak`                                                                        |
| [`3166c7c2`](https://github.com/NixOS/nixpkgs/commit/3166c7c29adcec9dbc8d985f7058d58d9b02beea) | `python39Packages.fastdiff: mark broken on 32bit`                                                                     |
| [`9e3b9853`](https://github.com/NixOS/nixpkgs/commit/9e3b985316169038739ce85227ead27e828c0aea) | `python3Packages.ipykernel: add missing deps and split off tests`                                                     |
| [`ebe4ea3b`](https://github.com/NixOS/nixpkgs/commit/ebe4ea3be238597bc974b98014b13d7048c3bf15) | `python3Packages.pykka: fix build, tests and refactor`                                                                |
| [`6914f2a3`](https://github.com/NixOS/nixpkgs/commit/6914f2a363492bdeaca570698daea82f77ee7baa) | `python3Packages.immutabledict: 2.1.0 -> 2.2.0`                                                                       |
| [`754c7ed6`](https://github.com/NixOS/nixpkgs/commit/754c7ed6e08ee0d7fb554127a73facf1bc238edc) | `azure-cli: fix build`                                                                                                |
| [`cce484c6`](https://github.com/NixOS/nixpkgs/commit/cce484c6c478c720d519c0d6804c57062128bacd) | `python3Packages.azure-mgmt-iothubprovisioningservices: fix build`                                                    |
| [`7d130e3f`](https://github.com/NixOS/nixpkgs/commit/7d130e3fbd2a0eb24d7e5bceb16428cf2283e38d) | `home-assistant: relax httpx, requests constraints`                                                                   |
| [`c16fb103`](https://github.com/NixOS/nixpkgs/commit/c16fb103bae6f56428d44ff07720472e0bb4fb0e) | `python2Packages.decorator: reinit at 4.4.2`                                                                          |
| [`f107f026`](https://github.com/NixOS/nixpkgs/commit/f107f026404e04052e729699a2a2776b4850f5fb) | `python39Packages.bellows: disable failing tests`                                                                     |
| [`bae58aed`](https://github.com/NixOS/nixpkgs/commit/bae58aed5adfdac724e711eeaf9e5839fc3bc845) | `python3Packages.pylitterbot: 2021.8.0 -> 2021.8.1`                                                                   |
| [`76c4d7bd`](https://github.com/NixOS/nixpkgs/commit/76c4d7bdc4c447d16597d453760088e1727ec82d) | `maturin: 0.10.6 -> 0.11.3`                                                                                           |
| [`6f7e7622`](https://github.com/NixOS/nixpkgs/commit/6f7e7622027438a994811a56b10f98c0fd222223) | `platformio: pin ajsonrpc dependency`                                                                                 |
| [`083c666d`](https://github.com/NixOS/nixpkgs/commit/083c666d20e9c497b76b9cef096b62c3db7d9de1) | `awscli: 1.19.97 -> 1.19.106`                                                                                         |
| [`dc4ba4d4`](https://github.com/NixOS/nixpkgs/commit/dc4ba4d4bf591d4494304c471233ed13917c01f1) | `python3Packages.boto3: 1.17.97 -> 1.17.106`                                                                          |
| [`48713fb7`](https://github.com/NixOS/nixpkgs/commit/48713fb7c0446a4ab4e15fd870c05a4a7fe10f84) | `python3Packages.botocore: 1.20.97 -> 1.20.106`                                                                       |
| [`0c205376`](https://github.com/NixOS/nixpkgs/commit/0c2053760fca84ba13a9b597eef0b94314a2b059) | `python39Packages.slowapi: disable failing tests`                                                                     |
| [`308c47e6`](https://github.com/NixOS/nixpkgs/commit/308c47e656cd15254ba573224ddff2ff31994f06) | `python39Packages.sanic-testing: loose httpx constraint`                                                              |
| [`5b7bb40a`](https://github.com/NixOS/nixpkgs/commit/5b7bb40a3cc9efd6dbc87dc7231a4bade363e18c) | `wapiti: disable failing test`                                                                                        |
| [`adc29d96`](https://github.com/NixOS/nixpkgs/commit/adc29d968471c2167759da96be208fd566983138) | `python39Packages.plotly: update meta, add tenacity hard depedency, removed no longer mentioned optional depedencies` |
| [`f0bd879f`](https://github.com/NixOS/nixpkgs/commit/f0bd879fdb29fbe24321e2e1ed86b84a3c3e192d) | `python39Packages.keyring: disable failing test`                                                                      |
| [`99ba0c04`](https://github.com/NixOS/nixpkgs/commit/99ba0c047950e18731dab16bb2026cfe4dbab96f) | `python39Packages.fastapi: format, disable failing test`                                                              |