### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5fe7b30633fcdc5cca2b7a1f5459b71c66ca6b88",
-        "sha256": "1bz7qf57vmz5jrky4zc868xpjgjln3mbrx1h6whji5xb3kb0fwd9",
+        "rev": "9f75aabfb06346e7677fc3ad53cc9b6669eead61",
+        "sha256": "14xh7r0jbpjdvzxzys72z5260hladckcj0c2bpgpdi5gq2xbx6yi",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5fe7b30633fcdc5cca2b7a1f5459b71c66ca6b88.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/9f75aabfb06346e7677fc3ad53cc9b6669eead61.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`47bbde4a`](https://github.com/NixOS/nixpkgs/commit/47bbde4a54bb43043e6a8bfa8fe5c1d379fb89a8) | `zellij: 0.16.0 -> 0.17.0`                                                 |
| [`70b65c28`](https://github.com/NixOS/nixpkgs/commit/70b65c281df5cfcf98cbe7dc3531b0ece0b5afd7) | `dua: 2.14.4 -> 2.14.6`                                                    |
| [`4828eb7a`](https://github.com/NixOS/nixpkgs/commit/4828eb7ae4f1105dcebf7245f453c607b9c77c1d) | `vscodium: 1.60.0 -> 1.60.1`                                               |
| [`cf755399`](https://github.com/NixOS/nixpkgs/commit/cf755399718e2d1a1c7f36b48d95c56450f5ecef) | `nixos/home-assistant: allow serial access for usb discovery and zwave_js` |
| [`5de4afa6`](https://github.com/NixOS/nixpkgs/commit/5de4afa614032055405cb234ca98e541c7f55307) | `home-assistant: 2021.8.8 -> 2021.9.6`                                     |
| [`b63e4fc8`](https://github.com/NixOS/nixpkgs/commit/b63e4fc84b0aa9fb29887530a1ea11f8ba13aeda) | `python3Packages.stdlib-list: init at 0.8.0`                               |
| [`f702a640`](https://github.com/NixOS/nixpkgs/commit/f702a64062abfa6fe2d5aeb8eb30eb88025be1cf) | `python3Packages.async-upnp-client: 0.21.0 -> 0.21.3`                      |
| [`15259dfa`](https://github.com/NixOS/nixpkgs/commit/15259dfa2c1eee31963060482973142f63f03650) | `python3Packages.herepy: relax requests constraint`                        |
| [`2d9604be`](https://github.com/NixOS/nixpkgs/commit/2d9604be7e9af0e980bf7df243208eaa71c82f66) | `python3Packages.zwave-js-server-python: 0.28.0 -> 0.30.0`                 |
| [`a9de5531`](https://github.com/NixOS/nixpkgs/commit/a9de55317e3f0a6a43cedf3b8db9cb94a60dea2c) | `python3Packages.zigpy-deconz: 0.12.1 -> 0.13.0`                           |
| [`3296526c`](https://github.com/NixOS/nixpkgs/commit/3296526c34b7e2409469b9d0f368fc4538c6772c) | `python3Packages.zha-quirks: 0.0.59 -> 0.0.61`                             |
| [`2d33f52f`](https://github.com/NixOS/nixpkgs/commit/2d33f52f474e6250fe61ea353b11b44feade2ef3) | `python3Packages.pymodbus: 2.5.2 -> 2.5.3rc1`                              |
| [`1cf568ae`](https://github.com/NixOS/nixpkgs/commit/1cf568ae28121b17b0a3c5c9615a7394b08d8e9d) | `python3Packages.bellows: 0.26.0 -> 0.27.0`                                |
| [`716f05ea`](https://github.com/NixOS/nixpkgs/commit/716f05ea514ee561b4e52a1b5093ae91f4523228) | `python3Packages.snitun: 0.27.0 -> 0.30.0`                                 |
| [`465ec543`](https://github.com/NixOS/nixpkgs/commit/465ec543658691b12b43cfb236033bc6047564e8) | `python3Packages.pymyq: 3.1.3 -> 3.1.4`                                    |
| [`677c17fe`](https://github.com/NixOS/nixpkgs/commit/677c17fe74c9f9961231e563fdb527e4ce28141c) | `python3Packages.aioswitcher: 2.0.4 -> 2.0.5`                              |
| [`251ff92d`](https://github.com/NixOS/nixpkgs/commit/251ff92d53fd89e0b9b39a3a5e1d5bf1f753a3a5) | `python3Packages.soco: 0.23.3 -> 0.24.0`                                   |
| [`9f76c53a`](https://github.com/NixOS/nixpkgs/commit/9f76c53a301cdafe641894608891abf7a76a742f) | `python3Packages.env-canada: 0.5.0 -> 0.5.1`                               |
| [`19c8d521`](https://github.com/NixOS/nixpkgs/commit/19c8d521bb43cff4c46aeea7ff56ba5de98dd794) | `python3Packages.yeelight: 0.7.2 -> 0.7.4`                                 |
| [`7b779214`](https://github.com/NixOS/nixpkgs/commit/7b77921490b9fb8d08ecc0ed7d986a71c3a51e66) | `python3Packages.pyopenuv: 2.1.0 -> 2.2.0`                                 |
| [`dc85b1cb`](https://github.com/NixOS/nixpkgs/commit/dc85b1cbda47f1f52cae98958248670b675dc8f4) | `python3Packages.pyiqvia: 1.0.1 -> 1.1.0`                                  |
| [`a84555ba`](https://github.com/NixOS/nixpkgs/commit/a84555ba2e332b5d51e1a19eab105229c0dd7a76) | `python3Packages.aioambient: 1.2.6 -> 1.3.0`                               |
| [`d3e7c6df`](https://github.com/NixOS/nixpkgs/commit/d3e7c6df189612be0ba0eb08e56ccee10b51a953) | `owncloud-client: 2.8.4 -> 2.9.0  (#135876)`                               |
| [`ff342ae2`](https://github.com/NixOS/nixpkgs/commit/ff342ae23b60d8427d5e2a7a98f3e5ba70d5cdea) | `ffmpeg-normalize: 1.22.1 -> 1.22.3`                                       |
| [`f52575c0`](https://github.com/NixOS/nixpkgs/commit/f52575c06b8d22263c78d0efba32b396e5422a31) | `tflint: 0.32.0 -> 0.32.1`                                                 |
| [`159c59a6`](https://github.com/NixOS/nixpkgs/commit/159c59a6b97c8dccdeced3d4eb772717d6bf4306) | `terracognita: 0.7.2 -> 0.7.3`                                             |
| [`7566d367`](https://github.com/NixOS/nixpkgs/commit/7566d3679a0a74a9ad9b242693b9b25ddd9d9e51) | `esphome: 2021.8.2 -> 2021.9.0`                                            |
| [`c706ca58`](https://github.com/NixOS/nixpkgs/commit/c706ca58e06328c98a9dfc8e9e069a60f2864237) | `rpg-cli: 0.6.0 -> 1.0.0`                                                  |
| [`9574e574`](https://github.com/NixOS/nixpkgs/commit/9574e57471eeb85b9a214eca7445c0ac13069c6e) | `resvg: 0.17.0 -> 0.18.0`                                                  |
| [`70945040`](https://github.com/NixOS/nixpkgs/commit/709450400c762ab70f023f00ad37dfb6b8e6b27d) | `pueue: 0.12.2 -> 1.0.2`                                                   |
| [`132593e3`](https://github.com/NixOS/nixpkgs/commit/132593e334377251bb178d93c107fbb644630742) | `session-desktop-appimage: 1.6.11 -> 1.7.1`                                |
| [`ca831be5`](https://github.com/NixOS/nixpkgs/commit/ca831be54c1588b44d3452f79a4cfa540a341856) | `miniserve: 0.15.0 -> 0.17.0`                                              |
| [`4872d2ed`](https://github.com/NixOS/nixpkgs/commit/4872d2ed2a2b5cfb9ac0d2503b0650128a114ba3) | `nushell: 0.36.0 -> 0.37.0`                                                |
| [`ea1775ee`](https://github.com/NixOS/nixpkgs/commit/ea1775eeee16627ddaa8c9f04776303ea9144421) | `strace: remove strace-graph stuff`                                        |
| [`3c4b11f2`](https://github.com/NixOS/nixpkgs/commit/3c4b11f25dcd0bb6a060872a63b08d1f6087bd40) | `python3Packages.migen: init at unstable-2021-09-14`                       |
| [`5196b3df`](https://github.com/NixOS/nixpkgs/commit/5196b3df7c687195388986b440934b7b2068ee72) | `tree-sitter: update grammars`                                             |
| [`20b905a8`](https://github.com/NixOS/nixpkgs/commit/20b905a8dfe4a65e18fce7fa9bd919f00ff3a9bd) | `alternatives/blas: fix ILP64 check`                                       |
| [`dc34788a`](https://github.com/NixOS/nixpkgs/commit/dc34788a25664926a04393d5f20a266c4a884385) | `nixos/lock-kernel-modules: use `udevadm settle``                          |
| [`82397b84`](https://github.com/NixOS/nixpkgs/commit/82397b844d8bf4e84e694e2be836cadd3ab6be31) | `multimc: user-provided client ID`                                         |
| [`c2d97ef7`](https://github.com/NixOS/nixpkgs/commit/c2d97ef72de1b96dfd0e4f51fb7253f9aaf5cf7d) | `exoscale-cli: 1.40.5 -> 1.41.0`                                           |
| [`473c9001`](https://github.com/NixOS/nixpkgs/commit/473c90014fbbe65dab653260d648084276219301) | `cobalt: 0.17.0 -> 0.17.4`                                                 |
| [`51e8290b`](https://github.com/NixOS/nixpkgs/commit/51e8290b19b376d6432cf7e6c6039d8da0db23d9) | `xmrig-mo: 6.14.1-mo2 -> 6.15.0-mo1`                                       |
| [`3b61e2c2`](https://github.com/NixOS/nixpkgs/commit/3b61e2c2b972505ccb77fd5e4d4c607dc1371148) | `tree-sitter: add rydesun/tree-sitter-dot`                                 |
| [`e9afd042`](https://github.com/NixOS/nixpkgs/commit/e9afd04202c745a0a251a530634e122d92550c2a) | `mit-scheme: set MITSCHEME_LIBRARY_PATH properly`                          |
| [`82510b5a`](https://github.com/NixOS/nixpkgs/commit/82510b5a519a44b76ac6db84861b5fcdb989d2a2) | `the-powder-toy: 96.1.349 -> 96.2.350`                                     |
| [`1dc2e2aa`](https://github.com/NixOS/nixpkgs/commit/1dc2e2aa8c3b3dd12cfc407faf1ba5c145a5599f) | `terragrunt: 0.31.7 -> 0.31.11`                                            |
| [`e2cce9e0`](https://github.com/NixOS/nixpkgs/commit/e2cce9e0ca53578229099d08baf0b52794bbad4b) | `sniffglue: 0.13.0 -> 0.13.1`                                              |
| [`82367d85`](https://github.com/NixOS/nixpkgs/commit/82367d8543e8c3b703911e1a429896d54b805c84) | `pure-prompt: 1.17.1 -> 1.17.2`                                            |
| [`8f6aa1f1`](https://github.com/NixOS/nixpkgs/commit/8f6aa1f1daaf171d2ca068804228a96fff2e69c0) | `pt2-clone: 1.32 -> 1.33`                                                  |
| [`90b0fda3`](https://github.com/NixOS/nixpkgs/commit/90b0fda38eb250505aa027e8ae4ebbf746eb96e6) | `opencolorio: 2.0.1 -> 2.0.2`                                              |
| [`3f5ad2d3`](https://github.com/NixOS/nixpkgs/commit/3f5ad2d345abac18d99b1b98bfd69cef536072d2) | `minify: 2.9.21 -> 2.9.22`                                                 |
| [`c55a7ebc`](https://github.com/NixOS/nixpkgs/commit/c55a7ebc5728765b6c0b2854d1f68560d81692db) | `linode-cli: 5.8.2 -> 5.9.0`                                               |
| [`c2743d7e`](https://github.com/NixOS/nixpkgs/commit/c2743d7e787b7e0e19edd219f28136a33b25d87a) | `tendermint: 0.34.12 -> 0.34.13`                                           |
| [`f3735c9d`](https://github.com/NixOS/nixpkgs/commit/f3735c9dd709d5a428117f5b1baf38675b4b7bf3) | `symfony-cli: 4.25.5 -> 4.26.0`                                            |
| [`2bf7e53b`](https://github.com/NixOS/nixpkgs/commit/2bf7e53bc3044575fcb69a27942ed355d2ce0d1d) | `wtf: 0.38.0 -> 0.39.2`                                                    |
| [`ab13dc43`](https://github.com/NixOS/nixpkgs/commit/ab13dc4381e6fd6430a5d33cf71fae66f458dc5a) | `vnstat: 2.7 -> 2.8`                                                       |
| [`34d91e67`](https://github.com/NixOS/nixpkgs/commit/34d91e675bfac9cfed653b88ae3093357bd6d59f) | `ntttcp: init at 1.4.0`                                                    |
| [`a6294ed2`](https://github.com/NixOS/nixpkgs/commit/a6294ed2932216d1fd4dcde4f7bd818705d388e2) | `python38Packages.pynanoleaf: 0.1.0 -> 0.1.1`                              |
| [`4c30cd11`](https://github.com/NixOS/nixpkgs/commit/4c30cd112cce47cace1ac424072ef360c35a3349) | `vscode-extensions.tobiasalthoff.atom-material-theme: init at 1.10.7`      |
| [`03111112`](https://github.com/NixOS/nixpkgs/commit/03111112cc69ed3a90d5b538c5c73d3f565da247) | `qgroundcontrol: 4.1.3 -> 4.1.4`                                           |
| [`3ca47430`](https://github.com/NixOS/nixpkgs/commit/3ca47430513672fc42f1bb9f85bfecdb1618df05) | `python38Packages.bitarray: 2.3.3 -> 2.3.4`                                |
| [`fd48ed50`](https://github.com/NixOS/nixpkgs/commit/fd48ed5022b6c367adbffcfc7aa89a694f5508e6) | `multimc: unstable-2021-06-21 -> unstable-2021-09-08`                      |
| [`f45e8d56`](https://github.com/NixOS/nixpkgs/commit/f45e8d560e391ac1a846cf89388ed3d6279d49af) | `nixos/tmp: add tmpOnTmpfsSize`                                            |
| [`5da0c385`](https://github.com/NixOS/nixpkgs/commit/5da0c38517f6c85f2831a235ff6ef4d96ff9e1ec) | `session-desktop-appimage: init at 1.6.11`                                 |
| [`2a54e05c`](https://github.com/NixOS/nixpkgs/commit/2a54e05c1cfeea0d765615a2484717f8d54a7a54) | `bisq-desktop: 1.7.2 -> 1.7.3`                                             |
| [`e6e71a13`](https://github.com/NixOS/nixpkgs/commit/e6e71a137de448e43c2a3e680e0cabb75e648fa4) | `gradle: 7.1.1 -> 7.2`                                                     |
| [`ea1a4b35`](https://github.com/NixOS/nixpkgs/commit/ea1a4b35e5adbb6d6fd11257ca36e67e1a401876) | `maintainers: add alexnortung`                                             |
| [`07d6a1a7`](https://github.com/NixOS/nixpkgs/commit/07d6a1a78c7d0833c05d140866708b076a60697e) | `eclipses: 2021-03 -> 2021-06`                                             |
| [`79bab74f`](https://github.com/NixOS/nixpkgs/commit/79bab74f0ec63353f694a6bb7e2faa5630926dbf) | `bitwig-studio: fix gtk file dialog`                                       |
| [`4395aa32`](https://github.com/NixOS/nixpkgs/commit/4395aa32b3699acd73b9a579578dc653b8500444) | `toxic: 0.10.1 -> 0.11.1`                                                  |