### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ab9569913ad347f8adcd9f80f3d14e6c26f0a1d5",
-        "sha256": "0lhzvx28fx508s82j6j9cc95ia4694cv5fiid0jskc0k9gq5rq13",
+        "rev": "d6b683c0527a7f777b5f2b4db2555891cd5a85f5",
+        "sha256": "0mkinbg2s4mg1ngh773h7rqc898siyigwy2wfz8jaai8k9srpx1n",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ab9569913ad347f8adcd9f80f3d14e6c26f0a1d5.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d6b683c0527a7f777b5f2b4db2555891cd5a85f5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`744f1893`](https://github.com/NixOS/nixpkgs/commit/744f189376edead6ff69ba8c0a215a73801d46e1) | `tdesktop: Add maintainer vanilla`                                             |
| [`4956c34a`](https://github.com/NixOS/nixpkgs/commit/4956c34a185aca1065bbd56cdee13df31bfcd0ab) | `vscode-extensions.angular.ng-template: 12.1.2 -> 12.2.0`                      |
| [`ea7049ce`](https://github.com/NixOS/nixpkgs/commit/ea7049cef22e6243e84d67ace81f1d70d2ff34ca) | `vscode-extensions.usernamehw.errorlens: 3.2.4 -> 3.4.0`                       |
| [`c5d87651`](https://github.com/NixOS/nixpkgs/commit/c5d876511301cdcb8a3d4de8c09a681fa128e172) | `nginx: fix URLs by taking from a specific commit`                             |
| [`74c572d2`](https://github.com/NixOS/nixpkgs/commit/74c572d2f8542142907696eda82f8c4ced383045) | `nixos/vmware-guest: fix setuid wrapper`                                       |
| [`035a6e80`](https://github.com/NixOS/nixpkgs/commit/035a6e805f28bc810ad0e745d6d0e4180b6650d5) | `libpsm2: disable blanket -Werror (gcc-11 fix)`                                |
| [`6139dd3a`](https://github.com/NixOS/nixpkgs/commit/6139dd3a1be86b198db12567b57b993914e51197) | `libpsm2: whitespace`                                                          |
| [`0cd345bc`](https://github.com/NixOS/nixpkgs/commit/0cd345bcc470627d057eb94afa5a470fbb24830a) | `tv: 0.5.3 -> 0.6.0`                                                           |
| [`857c478c`](https://github.com/NixOS/nixpkgs/commit/857c478cbd7758ef7d985900b37ceb3ec3fe2a2d) | `python3Packages.python3-application: init at 3.0.3`                           |
| [`8fc20dfd`](https://github.com/NixOS/nixpkgs/commit/8fc20dfdca1c32e645dcf661f14f358d7ef8f2c4) | `libebml: upstream fix for gcc-11`                                             |
| [`d236e2cf`](https://github.com/NixOS/nixpkgs/commit/d236e2cfb4bd874e831e730942f2ed767334d425) | `fundoc: init at 0.4.1`                                                        |
| [`762ad924`](https://github.com/NixOS/nixpkgs/commit/762ad924f3c124b59d7dab27cfd8c77ad79bca76) | `python3Packages.python3-eventlib: init at 0.3.0`                              |
| [`8693ab06`](https://github.com/NixOS/nixpkgs/commit/8693ab06727dafe1885e5794355e48834f568fce) | `maintainers: add chanley`                                                     |
| [`c2c5c3da`](https://github.com/NixOS/nixpkgs/commit/c2c5c3da83681b73faf2b98ca80563939ebd8369) | `rust-petname: init at 1.1.1`                                                  |
| [`d0da4cba`](https://github.com/NixOS/nixpkgs/commit/d0da4cba4b960c19c902e65aec9cc21589d42d5e) | `fakeroot: Use a fixed git commit as a reference in patch URLs`                |
| [`e1768bdb`](https://github.com/NixOS/nixpkgs/commit/e1768bdbfdb9a3d318179a3223a0d35badb693b0) | `cargo-cross: set meta.mainProgram`                                            |
| [`f0fac59a`](https://github.com/NixOS/nixpkgs/commit/f0fac59a17557329024df8a031df6bac1c5f5e9f) | `nixos/tpm2: remove tss static gid`                                            |
| [`9bfb8263`](https://github.com/NixOS/nixpkgs/commit/9bfb82638b951d4898aa42721d94d214a2fbcc91) | `fluxcd: 0.17.1 -> 0.17.2`                                                     |
| [`b6f4a80c`](https://github.com/NixOS/nixpkgs/commit/b6f4a80c7126ebb46aece494544fd4c21d47c3fd) | `cdo: 1.9.7.1 -> 1.9.10`                                                       |
| [`fd88e0ce`](https://github.com/NixOS/nixpkgs/commit/fd88e0ce04da8431ade5c2112c1a7c18cce9f3e3) | `vapoursynth: R54 -> R55`                                                      |
| [`1bb9a3e4`](https://github.com/NixOS/nixpkgs/commit/1bb9a3e44a4ec6e874b46609a7885e32f211e71f) | `python3.pkgs.panflute: fix build`                                             |
| [`8b8348ea`](https://github.com/NixOS/nixpkgs/commit/8b8348ea69ee52320e90317b97efd9ac3206a1b6) | `cargo-deadlinks: init at 0.8.0`                                               |
| [`23acc562`](https://github.com/NixOS/nixpkgs/commit/23acc562d28bcffa29e66a83a85cfdc7158e852a) | `amber: init at 0.1.1 (#138159)`                                               |
| [`4790fab6`](https://github.com/NixOS/nixpkgs/commit/4790fab62ff73f374c56635012c0045be151b98b) | `nixopsUnstable: fix version output`                                           |
| [`d3018c45`](https://github.com/NixOS/nixpkgs/commit/d3018c4522053afbb58cc067d4b9dec17bc034c1) | `importCargoLock: introduce alternative parameter `lockFileContents``          |
| [`84cf9203`](https://github.com/NixOS/nixpkgs/commit/84cf92039c8c44f12bae560b16675f4fc0ede93d) | `visidata: 2.5 -> 2.6`                                                         |
| [`150db8e3`](https://github.com/NixOS/nixpkgs/commit/150db8e3c8f6415fba50e6d1071909dea4d1bf84) | `tdesktop  3.0.1 -> 3.1.0`                                                     |
| [`94c03a01`](https://github.com/NixOS/nixpkgs/commit/94c03a01f4aac3e78e14247a9ecaffcfe1b9c578) | `sngrep: specify license`                                                      |
| [`0695f657`](https://github.com/NixOS/nixpkgs/commit/0695f657678893d9cca657491a46c68a2adcf541) | `whsniff: specify license`                                                     |
| [`78c2be85`](https://github.com/NixOS/nixpkgs/commit/78c2be85d7cce69491894bafa819d5592e1c8b92) | `rubyPackages.ansi: init at 1.5.0 (#138240)`                                   |
| [`bac5fde0`](https://github.com/NixOS/nixpkgs/commit/bac5fde048203c8cd5f1f5445f38757383223f4d) | `yt-dlp: add option to install a youtube-dl alias`                             |
| [`5c965b8c`](https://github.com/NixOS/nixpkgs/commit/5c965b8cc82cb41cdd135a19c0f33927f5a77109) | `gofu: create symlinks to applets`                                             |
| [`20291381`](https://github.com/NixOS/nixpkgs/commit/20291381c1e79eda0d5efbf3470440f270a7dee6) | `coqPackages.mkCoqDerivation: rely on namePrefix to compute default opam-name` |
| [`00a66c45`](https://github.com/NixOS/nixpkgs/commit/00a66c45e59ad9fa5cc7a37c31fc0245c09cb630) | `capnproto: update homepage and correct license`                               |
| [`173a24fc`](https://github.com/NixOS/nixpkgs/commit/173a24fc5c9df0f3d6c09c7fdcbb6e940b3f7127) | `notcurses: 2.3.8 -> 2.4.1`                                                    |
| [`93c56d87`](https://github.com/NixOS/nixpkgs/commit/93c56d878df28d2d043f58bab86efe095cad3b33) | `python3Packages.asyncstdlib: 3.9.2 -> 3.10.1`                                 |
| [`57070db5`](https://github.com/NixOS/nixpkgs/commit/57070db5851b8c547ab8988d0d33ae397aa45738) | `python3Packages.env-canada: 0.5.1 -> 0.5.12`                                  |
| [`9dd22577`](https://github.com/NixOS/nixpkgs/commit/9dd225773bee4de17ba642733473ec6a87d7d6d3) | `python3Packages.deezer-python: 2.3.0 -> 2.3.1`                                |
| [`88ae01f6`](https://github.com/NixOS/nixpkgs/commit/88ae01f67969a7b5b798f8fd3944591cc54fa1f7) | `sslh: 1.21c → 1.22c`                                                          |
| [`489af570`](https://github.com/NixOS/nixpkgs/commit/489af5702ad9d5dcc0d1b35df10150fcc4f39684) | `python3Packages.pyupgrade: 2.25.1 -> 2.26.0`                                  |
| [`1b9ce343`](https://github.com/NixOS/nixpkgs/commit/1b9ce343d4639cddbf1c75647186836389ab1171) | `python3Packages.slack-sdk: 3.11.1 -> 3.11.1`                                  |
| [`2610f6e0`](https://github.com/NixOS/nixpkgs/commit/2610f6e0df09dd43bdc5da5b28674aa056e8a412) | `nixos/panthoen: mention appcenter changes in manual`                          |
| [`50840cc6`](https://github.com/NixOS/nixpkgs/commit/50840cc6d2b06433c2fc1d2668f0e07992cf1fd1) | `octoprint/costestimation: fix homepage & fmt`                                 |
| [`9e421bf4`](https://github.com/NixOS/nixpkgs/commit/9e421bf4225feabd91daae8aa8df4432a2248201) | `wavemon: 0.9.3 -> 0.9.4`                                                      |
| [`bd28ff08`](https://github.com/NixOS/nixpkgs/commit/bd28ff08d30e30b2753acb6c7fe3e7b8c4c43b7d) | `nixos/greetd: Fix for nogroup removal.`                                       |
| [`e17be72e`](https://github.com/NixOS/nixpkgs/commit/e17be72e67524570704353128d444a1826166cdd) | `nuclei: 2.5.1 -> 2.5.2`                                                       |
| [`eaaf989c`](https://github.com/NixOS/nixpkgs/commit/eaaf989c1c61796775585eb7a35ffe3a3c1f30bc) | `nvidia_x11: Remove maintainer baracoder`                                      |
| [`3ec1a47f`](https://github.com/NixOS/nixpkgs/commit/3ec1a47f2e1f906915eed76d13dc115a7bc2b0d1) | `treewide: remove @sdll from maintainers`                                      |
| [`e2530059`](https://github.com/NixOS/nixpkgs/commit/e253005922e824df12573a141e58c053db9ecd15) | `linkerd_edge: 21.8.2 -> 21.9.3`                                               |
| [`b88b46b8`](https://github.com/NixOS/nixpkgs/commit/b88b46b830d31db6a532a3302c3e98a6697aee08) | `nixos/tcsd: make group uid dynamic`                                           |
| [`8b6fa3c8`](https://github.com/NixOS/nixpkgs/commit/8b6fa3c8216e0fdb802ffd2415422c9d7e6c9dcb) | `nixos/tpm2: define group, fix after NixOS#133166`                             |
| [`8bc87791`](https://github.com/NixOS/nixpkgs/commit/8bc8779136833012f9f802899fcdcb75d6ce3bb3) | `svd2rust: 0.18.0 -> 0.19.0`                                                   |
| [`84a9b1f3`](https://github.com/NixOS/nixpkgs/commit/84a9b1f3a21b96f3063b9bd2f4d044e2316dce56) | `rpm: 4.16.1.3 -> 4.17.0`                                                      |
| [`1bd7260a`](https://github.com/NixOS/nixpkgs/commit/1bd7260adb4233816cc33ef6e7da667aee1c0a79) | `nixos/lock-kernel-modules: reorder before/after`                              |
| [`3e913956`](https://github.com/NixOS/nixpkgs/commit/3e913956926d118e8850dfa85c21599f1c43d603) | `helmfile: 0.140.0 -> 0.140.1`                                                 |
| [`40a4e834`](https://github.com/NixOS/nixpkgs/commit/40a4e8347383177fe4568ff7dea9d8c7f435edec) | `python3Packages.amcrest: 1.9.2 -> 1.9.3`                                      |
| [`5fc4fdac`](https://github.com/NixOS/nixpkgs/commit/5fc4fdac51a952c03692946d0ba66e7b42b751e9) | `terraform-ls: 0.21.0 -> 0.22.0`                                               |
| [`eb88a99e`](https://github.com/NixOS/nixpkgs/commit/eb88a99ebf92c365d50b5184b8e4c6454c191155) | `wrangler: 1.19.2 -> 1.19.3`                                                   |
| [`ff790525`](https://github.com/NixOS/nixpkgs/commit/ff7905256c42067aa89714afd873fae25b6965a1) | `clojure-lsp: 2021.09.04-17.11.44 -> 2021.09.13-22.25.35`                      |
| [`b8d70831`](https://github.com/NixOS/nixpkgs/commit/b8d708318d31df4d91ed7835ee11ffc4d5e0b2a0) | `mackerel-agent: 0.72.1 -> 0.72.2`                                             |
| [`810e595e`](https://github.com/NixOS/nixpkgs/commit/810e595e4e4d7a8dd10a694bb4103d694bebccaf) | `cudatoolkit: fix build`                                                       |
| [`29a24106`](https://github.com/NixOS/nixpkgs/commit/29a24106beb8a1ecb80c0ed1191eff4de90659fe) | `saleae-logic-2: 2.3.33 -> 2.3.37`                                             |
| [`6acd4f5b`](https://github.com/NixOS/nixpkgs/commit/6acd4f5b5ae542de4a9e2a5fd0a910d8340a6bdb) | `saleae-logic-2: add lib dependencies`                                         |
| [`d9e1adfa`](https://github.com/NixOS/nixpkgs/commit/d9e1adfa5dc43cba954054d9b18677fc92d9f198) | `buildkite-agent: 3.32.1 -> 3.32.3`                                            |
| [`9bf9c6bd`](https://github.com/NixOS/nixpkgs/commit/9bf9c6bde9704e31fefb482a3b2aebc8294b018a) | `pika-backup: 0.3.2 -> 0.3.5`                                                  |
| [`b4e53b15`](https://github.com/NixOS/nixpkgs/commit/b4e53b1517bd486b8c114d9971eb2b006dcddc6d) | `automysqlbackup: 3.0.6 -> 3.0.7`                                              |
| [`84218bee`](https://github.com/NixOS/nixpkgs/commit/84218bee0620661db255e8a6e8e89bea134792ca) | `kube-prompt: 1.0.5 -> 1.0.11`                                                 |
| [`e02b7478`](https://github.com/NixOS/nixpkgs/commit/e02b7478f7c13ccc1726732486804cbddee5293e) | `index-fm: 1.2.2 -> 2.0.0`                                                     |
| [`5598d61c`](https://github.com/NixOS/nixpkgs/commit/5598d61c913ffdcec495c0bb9219dec5245bea88) | `libsForQt5.mauikit-filebrowsing: 1.2.2 -> 2.0.1`                              |
| [`7abcd662`](https://github.com/NixOS/nixpkgs/commit/7abcd6621ad3a6e4c9664cf866a88e2a9e84f01a) | `libsForQt5.mauikit: 1.2.2 -> 2.0.1`                                           |
| [`c73efd42`](https://github.com/NixOS/nixpkgs/commit/c73efd42660187e19a19972b0d4b1ad8d1716025) | `pspg: 5.3.4 -> 5.3.5`                                                         |
| [`fcf3de84`](https://github.com/NixOS/nixpkgs/commit/fcf3de84498e91c8af2ad8eaf3a6f68442fb2508) | `proton-caller: 2.3.1 -> 2.3.2`                                                |
| [`51225920`](https://github.com/NixOS/nixpkgs/commit/512259201980f9c590c19bfebab0ea5b6c205ac0) | `noaa-apt: 1.3.0 -> 1.3.1`                                                     |
| [`88433eb5`](https://github.com/NixOS/nixpkgs/commit/88433eb5369367a00e0cac7cd7ece1276d9e284a) | `minio-client: 2021-07-27T06-46-19Z -> 2021-09-02T09-21-27Z`                   |
| [`b40e78de`](https://github.com/NixOS/nixpkgs/commit/b40e78de01086ab553c8c299911af6006c42fc61) | `libtpms: 0.8.4 -> 0.8.6`                                                      |
| [`d7f0ec1d`](https://github.com/NixOS/nixpkgs/commit/d7f0ec1d46ce788efa74393d4b5d9886ad8a269d) | `clojure-lsp: Add updateScript`                                                |
| [`a75b1fa5`](https://github.com/NixOS/nixpkgs/commit/a75b1fa5a9df17fe30ad986aef53010400a1888c) | `octavePackages: add documentation`                                            |
| [`b012fe5e`](https://github.com/NixOS/nixpkgs/commit/b012fe5e7ea86ef0f4de88ec80fa0e65113e1146) | `use --verbatim-files-from in dockerTools`                                     |
| [`52ffafe4`](https://github.com/NixOS/nixpkgs/commit/52ffafe4e2153a8d14fbf900789ba000a8bbb6e7) | `s2n-tls: 1.0.16 -> 1.0.17`                                                    |
| [`b875e26f`](https://github.com/NixOS/nixpkgs/commit/b875e26ffb4612707aac5ca9554c8ecf37e482bf) | `ulauncher: 5.11.0 -> 5.12.1`                                                  |
| [`e2e42dcf`](https://github.com/NixOS/nixpkgs/commit/e2e42dcf178df48e2b44e8bcfb6767389074ad51) | `vaultwarden: 1.22.1 -> 1.22.2`                                                |
| [`f7bb18d0`](https://github.com/NixOS/nixpkgs/commit/f7bb18d0d30de066db4e1f1b97f80f88cc77b2b4) | `particl-core: 0.19.2.5 -> 0.19.2.13`                                          |
| [`05e0e96c`](https://github.com/NixOS/nixpkgs/commit/05e0e96c3a8ffc56f4aaae1a8dc002fd6a454121) | `cpupower-gui: init at 1.0.0`                                                  |