### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d30701f2f17c18ca3096327dea5a6d09e26e8721",
-        "sha256": "1yr92z54rp8rkf29d6cp7kwc2gsf2dvfj1c1gr6yw95g37120gbs",
+        "rev": "841b22ab76741eb4d2edcb48117a688e7d7f1b24",
+        "sha256": "1jqr2x8sphppm8n8r49wdhqqsdfq3cqa0hmr4rai6j08gqcxnq0a",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d30701f2f17c18ca3096327dea5a6d09e26e8721.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/841b22ab76741eb4d2edcb48117a688e7d7f1b24.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`1b7e3b78`](https://github.com/NixOS/nixpkgs/commit/1b7e3b78b426cb4c70181359e1b794eb830b2b81) | `poetry2nix: 1.19.0 -> 1.20.0`                                                |
| [`470466fd`](https://github.com/NixOS/nixpkgs/commit/470466fdbd5991c0f7d81fa657e45458730ff7c8) | `sigtool: 4a3719b4 -> 2a13539d (#138453)`                                     |
| [`6f1e86d1`](https://github.com/NixOS/nixpkgs/commit/6f1e86d1a73e56cac98e22c271924b2736a8d83f) | `python38Packages.geoip2: 4.2.0 -> 4.3.0`                                     |
| [`ce598b2d`](https://github.com/NixOS/nixpkgs/commit/ce598b2dd104a7461dad37837e9f46d10ed51551) | `eccodes: remove top-level `with lib;``                                       |
| [`451b750a`](https://github.com/NixOS/nixpkgs/commit/451b750a8583dcd9f88a4d949dee3fac187ad67d) | `python38Packages.dropbox: 11.19.0 -> 11.20.0`                                |
| [`bf8d4178`](https://github.com/NixOS/nixpkgs/commit/bf8d41783ceff268b6e884ff0b2a6b7e12dfb921) | `python38Packages.django_environ: 0.5.0 -> 0.7.0`                             |
| [`5e7817e7`](https://github.com/NixOS/nixpkgs/commit/5e7817e75241e547db34d9da2bc8fea44d217562) | `unifi6: 6.2.26 -> 6.4.54`                                                    |
| [`b2b8978c`](https://github.com/NixOS/nixpkgs/commit/b2b8978c42a9b0143d060718d9414c3a38ced9a8) | `python38Packages.deezer-py: 1.2.2 -> 1.2.3`                                  |
| [`15fe6fc1`](https://github.com/NixOS/nixpkgs/commit/15fe6fc11921ec37bd1ea2fadc2fdd82d66808f4) | `whatsapp-for-linux: add wrapGAppsHook`                                       |
| [`c36249ac`](https://github.com/NixOS/nixpkgs/commit/c36249ac1d7ebcecb4a7bb0e77ec1374811ccaa1) | `eccodes: nixpkgs-fmt`                                                        |
| [`2fa0810d`](https://github.com/NixOS/nixpkgs/commit/2fa0810d11248a2767c9dae9a9c6dfea59252547) | `eccodes: 2.12.5 -> 2.23.0`                                                   |
| [`bdd60e76`](https://github.com/NixOS/nixpkgs/commit/bdd60e762d02011ac2ce930faa36067b50513e1c) | `python38Packages.commoncode: 21.8.27 -> 21.8.31`                             |
| [`fb1081ff`](https://github.com/NixOS/nixpkgs/commit/fb1081ffa79c779becf9de46a6897aa1f1044043) | `cvehound: init at 1.0.4`                                                     |
| [`b2391a51`](https://github.com/NixOS/nixpkgs/commit/b2391a51d25aa45679192abaf6b77b87fecfac93) | `coq: add desktop file for coqide`                                            |
| [`9f08c2d4`](https://github.com/NixOS/nixpkgs/commit/9f08c2d4b9e0dccc21df012353e05c38b7b71944) | `btop: init at 1.0.5`                                                         |
| [`f04c651d`](https://github.com/NixOS/nixpkgs/commit/f04c651d4c29b21317c10e5ff1857da60ec23686) | `python38Packages.chart-studio: 5.3.0 -> 5.3.1`                               |
| [`3bfbe118`](https://github.com/NixOS/nixpkgs/commit/3bfbe11864a3b363eb4e3f20ba1083cb19dbe33b) | `nix-index: remove null check, build on hydra`                                |
| [`3bcfecc2`](https://github.com/NixOS/nixpkgs/commit/3bcfecc268071364a6a781ef1b2ad6a6655c7d57) | `rnix-lsp: 0.1.0 -> 0.2.1`                                                    |
| [`d5927975`](https://github.com/NixOS/nixpkgs/commit/d59279752293329f429576da93ec005b8da59815) | `python38Packages.casbin: 1.7.0 -> 1.8.1`                                     |
| [`f616e094`](https://github.com/NixOS/nixpkgs/commit/f616e094fa92095f00371f7e04e4f0bacf436b7a) | `nix-index: wrap in a separate derivation`                                    |
| [`e0609ea9`](https://github.com/NixOS/nixpkgs/commit/e0609ea911edfe9ea550b779c4c44709f18dc239) | `nodePackages.carbon-now-cli: init at 1.4.0`                                  |
| [`b3303102`](https://github.com/NixOS/nixpkgs/commit/b3303102c5c78c3565e63159124af4f1f3f4077a) | `oh-my-zsh: 2021-09-15 -> 2021-09-22`                                         |
| [`73e9a7fc`](https://github.com/NixOS/nixpkgs/commit/73e9a7fcef1533bd23931d2d0b492d66b7bf2093) | `python38Packages.bids-validator: 1.8.2 -> 1.8.3`                             |
| [`cb906083`](https://github.com/NixOS/nixpkgs/commit/cb906083e5bcf5b24761abb45c36116af0c41ec7) | `libdigidocpp: 3.14.6 -> 3.14.7`                                              |
| [`38afa666`](https://github.com/NixOS/nixpkgs/commit/38afa666bef875434a47ffea66354b51bb54e4bb) | `python38Packages.azure-storage-file-share: 12.5.0 -> 12.6.0`                 |
| [`ccf7589b`](https://github.com/NixOS/nixpkgs/commit/ccf7589ba7e969b06de3aece0b99b857be26f296) | `python38Packages.azure-mgmt-servicebus: 7.0.0 -> 7.1.0`                      |
| [`23e4d82e`](https://github.com/NixOS/nixpkgs/commit/23e4d82e4cc1412f18f79620e61051799f78c486) | `libopenaptx: 0.2.0 -> 0.2.1`                                                 |
| [`c54902fa`](https://github.com/NixOS/nixpkgs/commit/c54902fad1fc57cc333e504524833ed551550125) | `python38Packages.azure-mgmt-kusto: 2.0.0 -> 2.1.0`                           |
| [`a26496bb`](https://github.com/NixOS/nixpkgs/commit/a26496bb5226caa7bf04527549c291a6a0ea85e7) | `python38Packages.awscrt: 0.12.0 -> 0.12.2`                                   |
| [`273cf4f4`](https://github.com/NixOS/nixpkgs/commit/273cf4f45ac4f2df7c6ebb2d8c0ec05a646af078) | `super-slicer.stable: 2.3.56.8 -> 2.3.56.9 (#136962)`                         |
| [`5ca89402`](https://github.com/NixOS/nixpkgs/commit/5ca89402eec1a634b2e94cdf407b92095cdacfa2) | `nixos/trafficserver: avoid input from derivation`                            |
| [`aabeb438`](https://github.com/NixOS/nixpkgs/commit/aabeb43868c14d93a0eeae65d225037292fc5835) | `python3Packages.furo: 2021.8.11b42 -> 2021.9.22`                             |
| [`19fc9cd6`](https://github.com/NixOS/nixpkgs/commit/19fc9cd629c0b9c98f50cd0e34ebc9b111a91798) | `python38Packages.Pyro4: 4.80 -> 4.81`                                        |
| [`ff0a5a63`](https://github.com/NixOS/nixpkgs/commit/ff0a5a63ef525c4edbdd39ac90083b077aaf7d20) | `plexRaw: 1.24.2.4973-2b1b51db9 -> 1.24.3.5033-757abe6b4`                     |
| [`de2f733a`](https://github.com/NixOS/nixpkgs/commit/de2f733af05a4f2d20e537f8eb85fc85607ed050) | `rclone: 1.56.0 -> 1.56.1`                                                    |
| [`b2e3a43c`](https://github.com/NixOS/nixpkgs/commit/b2e3a43c08f275574a70a243b060c8432255caa0) | `python3Packages.zeroconf: 0.36.6 -> 0.36.7`                                  |
| [`ea5c6b3a`](https://github.com/NixOS/nixpkgs/commit/ea5c6b3a6f3e6ea3945d584954b56ca029c49f38) | `dino: clarify license`                                                       |
| [`25f38c1a`](https://github.com/NixOS/nixpkgs/commit/25f38c1a3b5b50fed97a90a5c97a495cf8985601) | `dino: 0.2.1 -> 0.2.2`                                                        |
| [`93e7a9d5`](https://github.com/NixOS/nixpkgs/commit/93e7a9d51992283bcfefaf0e079af583604761bc) | `mkgmap: 4806 -> 4807`                                                        |
| [`729611ec`](https://github.com/NixOS/nixpkgs/commit/729611ecc0ffd6771ca6b50d4b88c692950cab9b) | `pscale: 0.72.0 -> 0.76.0`                                                    |
| [`0b86e289`](https://github.com/NixOS/nixpkgs/commit/0b86e289a5cd54ab8f4b0a571bfb0ad013000c86) | `proxmark3-rrg: 4.13441 -> 4.14434`                                           |
| [`56e94052`](https://github.com/NixOS/nixpkgs/commit/56e94052d5bfceac76526bc866b5915bd98b49ab) | `matrix-synapse-plugins.matrix-synapse-pam: 0.1.2 -> 0.1.3`                   |
| [`29a0578a`](https://github.com/NixOS/nixpkgs/commit/29a0578a1e8ee6a5a57a9eabd72569fc8a59b0b9) | `matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 0.1.19 -> 1.1.20`    |
| [`268e78ed`](https://github.com/NixOS/nixpkgs/commit/268e78edd59c69e58d7bddf87791882f2295d6da) | `praat: 6.1.52 -> 6.1.53`                                                     |
| [`5efd58cb`](https://github.com/NixOS/nixpkgs/commit/5efd58cbe03aee6cbaa1c39d9a967bc675f9412a) | `python38Packages.tempest: 28.0.0 -> 29.0.0`                                  |
| [`6faa22c2`](https://github.com/NixOS/nixpkgs/commit/6faa22c229d61e5e515730a63af4e00f348f69c5) | `python38Packages.html5-parser: 0.4.9 -> 0.4.10`                              |
| [`f79dfb7b`](https://github.com/NixOS/nixpkgs/commit/f79dfb7bbb03167ab24f7af9e535b4ec2dcfcc2b) | `python38Packages.sentry-sdk: 1.3.1 -> 1.4.1`                                 |
| [`bc4060b2`](https://github.com/NixOS/nixpkgs/commit/bc4060b217bb2d99098f79d946ffbdc5f84f297d) | `python38Packages.sseclient-py: 1.7 -> 1.7.2`                                 |
| [`dbf552e9`](https://github.com/NixOS/nixpkgs/commit/dbf552e9f037b30fb137c0d795790bbff14ad750) | `python38Packages.transmission-rpc: 3.2.7 -> 3.2.8`                           |
| [`a154fc89`](https://github.com/NixOS/nixpkgs/commit/a154fc89831da60169ba9165930c96a855e23b39) | `python38Packages.pybullet: 3.1.8 -> 3.1.9`                                   |
| [`d60563ef`](https://github.com/NixOS/nixpkgs/commit/d60563ef676c8a87588fb9521462f710335c4451) | `python38Packages.zarr: 2.9.4 -> 2.10.0`                                      |
| [`cd7dedc4`](https://github.com/NixOS/nixpkgs/commit/cd7dedc4e7ad8bb49670818452f161ac51dbd145) | `python38Packages.sopel: 7.1.3 -> 7.1.4`                                      |
| [`ce0130d5`](https://github.com/NixOS/nixpkgs/commit/ce0130d58a9ff40f885066edb67c0a69873bf888) | `python38Packages.youtube-search-python: 1.4.7 -> 1.4.8`                      |
| [`922a904f`](https://github.com/NixOS/nixpkgs/commit/922a904ff6039a9805b597a244b0b9ba4c7a3d99) | `python38Packages.r2pipe: 1.6.0 -> 1.6.2`                                     |
| [`8c51fc6e`](https://github.com/NixOS/nixpkgs/commit/8c51fc6eee5ad3920424a9ae39955a4d9dc240b5) | `python38Packages.trimesh: 3.9.30 -> 3.9.31`                                  |
| [`4c056cf4`](https://github.com/NixOS/nixpkgs/commit/4c056cf4624228144bb877686a2e1dbeeff8c46d) | `python38Packages.mechanize: 0.4.6 -> 0.4.7`                                  |
| [`62207eec`](https://github.com/NixOS/nixpkgs/commit/62207eec010d76e69b1ba75eb7f72af0c223a9c8) | `zerotierone: 1.6.5 -> 1.6.6`                                                 |
| [`405c90d2`](https://github.com/NixOS/nixpkgs/commit/405c90d2bfa1c87021a66d5a78549d3e05cbee4d) | `gitRepo: 2.16.7 -> 2.16.8`                                                   |
| [`0669232a`](https://github.com/NixOS/nixpkgs/commit/0669232a9c16252c6f90eeeda72705837e727b3f) | `python38Packages.pytest-testmon: 1.1.2 -> 1.2.0`                             |
| [`cdee5d00`](https://github.com/NixOS/nixpkgs/commit/cdee5d000977eb20472b994d9694a6a196146fa1) | `python38Packages.tasklib: 2.3.0 -> 2.4.0`                                    |
| [`1fc8c4ea`](https://github.com/NixOS/nixpkgs/commit/1fc8c4ea839aa4367cf0d7526357f6a02be79380) | `python38Packages.python-hosts: 1.0.1 -> 1.0.2`                               |
| [`afc9fafd`](https://github.com/NixOS/nixpkgs/commit/afc9fafd463082463dd3cb8225b66ce4ab34753e) | `python38Packages.Pyro4: 4.80 -> 4.81`                                        |
| [`09076132`](https://github.com/NixOS/nixpkgs/commit/0907613236adfa4a86a52ecea884c0f829d2e64e) | `python38Packages.wadllib: 1.3.5 -> 1.3.6`                                    |
| [`31eca1b1`](https://github.com/NixOS/nixpkgs/commit/31eca1b1ead9b4334f8a692427d7266976f6476b) | `python38Packages.pysdl2: 0.9.8 -> 0.9.9`                                     |
| [`aae8f3d3`](https://github.com/NixOS/nixpkgs/commit/aae8f3d3901b72d8998266f37e912d58a68753c8) | `python3Packages.in-place: init at 0.5.0`                                     |
| [`89e4c181`](https://github.com/NixOS/nixpkgs/commit/89e4c181e58be38326b8e0a13a3dd5ba495ff477) | `python38Packages.azure-storage-file-share: 12.5.0 -> 12.6.0`                 |
| [`da84d9e7`](https://github.com/NixOS/nixpkgs/commit/da84d9e7195b80a13dea3dd785ee2f42802057e8) | `python38Packages.bids-validator: 1.8.2 -> 1.8.3`                             |
| [`63391899`](https://github.com/NixOS/nixpkgs/commit/63391899a35d732e85eb90efb8cf0c59d12f1c11) | `pythonPackages.Theano: fix cuda package`                                     |
| [`6ccb5fa3`](https://github.com/NixOS/nixpkgs/commit/6ccb5fa3e75244d22921734f4038e2865d11615d) | `python38Packages.iminuit: 2.8.2 -> 2.8.3`                                    |
| [`fa1860fe`](https://github.com/NixOS/nixpkgs/commit/fa1860fec43c5d8c7f243682eb46500f2186b40f) | `python38Packages.commoncode: 21.8.27 -> 21.8.31`                             |
| [`77bda46f`](https://github.com/NixOS/nixpkgs/commit/77bda46f1be6d9a87db187c8c57127910a5ef1cb) | `python38Packages.awscrt: 0.12.0 -> 0.12.2`                                   |
| [`7ade5fad`](https://github.com/NixOS/nixpkgs/commit/7ade5fad8f6af055dbdf09e6cd643b3ce0b5a690) | `python38Packages.mypy-boto3-s3: 1.18.29 -> 1.18.46`                          |
| [`4735d5be`](https://github.com/NixOS/nixpkgs/commit/4735d5bec28f7322b2b8299e55cc30a97a9455e3) | `illum: 0.4 -> 0.5`                                                           |
| [`1660b2f6`](https://github.com/NixOS/nixpkgs/commit/1660b2f6c2d4746d3399a3f48ca5ecb5c30dd074) | `open-policy-agent: 0.32.0 -> 0.32.1`                                         |
| [`40d7fc85`](https://github.com/NixOS/nixpkgs/commit/40d7fc853f32d102babc30f491a0f46cefa817cd) | `python38Packages.ibm-watson: 5.2.3 -> 5.3.0`                                 |
| [`1dd63312`](https://github.com/NixOS/nixpkgs/commit/1dd63312e13aedc52d6ff8e9e4d4cd421a6849f8) | `nats-server: 2.5.0 -> 2.6.0`                                                 |
| [`27632203`](https://github.com/NixOS/nixpkgs/commit/276322039a9450561b93e2915fb3e742aef9572b) | `boundary: 0.6.0 -> 0.6.1`                                                    |
| [`06bcfffc`](https://github.com/NixOS/nixpkgs/commit/06bcfffc273ba77c2d862f650edab6238860d754) | `mlkit: 4.5.7 -> 4.5.9`                                                       |
| [`cbc705bb`](https://github.com/NixOS/nixpkgs/commit/cbc705bb3d69bd696ef472bebd451f567ebe13a1) | `bashate: 2.0.0 -> 2.1.0`                                                     |
| [`d2349615`](https://github.com/NixOS/nixpkgs/commit/d2349615d9d611236102c1ee2be81bbc542d4ab4) | `metabigor: 1.9 -> 1.10`                                                      |
| [`fcb7719e`](https://github.com/NixOS/nixpkgs/commit/fcb7719e3159377e4c467bfff6e40d5b8c9b5a7f) | `luna-icons: 1.3 -> 1.4`                                                      |
| [`0785430a`](https://github.com/NixOS/nixpkgs/commit/0785430a5eb74dfe2863f16914f1aea379b96dd1) | `linuxKernel.kernels.linux_xanmod: 5.14.6 -> 5.14.7`                          |
| [`b1ad7a53`](https://github.com/NixOS/nixpkgs/commit/b1ad7a530d148cd3ba4cb02b7ee13eed733109fc) | `kubesec: 2.11.3 -> 2.11.4`                                                   |
| [`281dd183`](https://github.com/NixOS/nixpkgs/commit/281dd1830d27faab2f806a0c7c75324ffe99747a) | `gleam: 0.16.1 -> 0.17.0`                                                     |
| [`7196b9b6`](https://github.com/NixOS/nixpkgs/commit/7196b9b61c33ac7ba6d0b0780ea0c79afeb6e0a0) | `esbuild: 0.12.28 -> 0.13.0`                                                  |
| [`143e73b2`](https://github.com/NixOS/nixpkgs/commit/143e73b2dee440fc2a5191c4b97fcd3b90e83524) | `kotlin: 1.5.30 -> 1.5.31`                                                    |
| [`77eb0d93`](https://github.com/NixOS/nixpkgs/commit/77eb0d932086c27267a21d484267fbde1b628f05) | `headscale: 0.7.1 -> 0.8.1`                                                   |
| [`6632becb`](https://github.com/NixOS/nixpkgs/commit/6632becbe02c7538a484758f3b57ac0fa19179d2) | `pantheon.switchboard-plug-mouse-touchpad: 6.0.0 -> 6.1.0`                    |
| [`6c6ad987`](https://github.com/NixOS/nixpkgs/commit/6c6ad98728ca12fa4091d0dfb2d80314defece77) | `pantheon.switchboard-plug-keyboard: 2.5.0  -> 2.5.1`                         |
| [`3984a189`](https://github.com/NixOS/nixpkgs/commit/3984a1898379ff3492dfa1f75c534944fd35cd54) | `pantheon.elementary-calendar: 6.0.1 -> 6.0.2`                                |
| [`ab0b955a`](https://github.com/NixOS/nixpkgs/commit/ab0b955aa9f28b42f1d4481ac423c0fa22301f6c) | `pantheon.elementary-greeter: 6.0.0 -> 6.0.1`                                 |
| [`8ffb8172`](https://github.com/NixOS/nixpkgs/commit/8ffb81729cf77922703aa2f1a4b6e83ee8ff4fdb) | `pantheon.sideload: 6.0.1 -> 6.0.2`                                           |
| [`a6005310`](https://github.com/NixOS/nixpkgs/commit/a6005310284fb1b5c76edd55f70e2a23fb0cfcd3) | `python38Packages.scrapy-deltafetch: 1.2.1 -> 2.0.1`                          |
| [`4788070d`](https://github.com/NixOS/nixpkgs/commit/4788070d4872fbba66287ccdbc9187d18784405c) | `pantheon.epiphany: remove fixme`                                             |
| [`35a2230d`](https://github.com/NixOS/nixpkgs/commit/35a2230d1d3e9b079a374e81893223261d8c233e) | `fishfight: init at 0.1`                                                      |
| [`5d038fdd`](https://github.com/NixOS/nixpkgs/commit/5d038fdd6971114f5b8b0f6f36971b0aefcaf0ae) | `inotify-tools: 3.20.11.0 -> 3.21.9.5`                                        |
| [`d32e0e6b`](https://github.com/NixOS/nixpkgs/commit/d32e0e6b1b6c308c28f954685cf63cf176db02af) | `llvmPackages_13.lld: add postPatch to fix Darwin build`                      |
| [`896ee5ff`](https://github.com/NixOS/nixpkgs/commit/896ee5ffc634473f63ce70829568c9b8156a13cf) | `idris2: 0.5.0 -> 0.5.1`                                                      |
| [`c1313e30`](https://github.com/NixOS/nixpkgs/commit/c1313e30fb12bec0e06a5460ef2a57e28707ea8f) | `htop: 3.0.5 -> 3.1.0`                                                        |
| [`91874d92`](https://github.com/NixOS/nixpkgs/commit/91874d92392a7afe90b0a1415e648c2fa229e436) | `prometheus-unbound-exporter: unstable-2021-03-17 -> unstable-2021-09-18`     |
| [`6de529c6`](https://github.com/NixOS/nixpkgs/commit/6de529c64abcd435f64e1b3fd521efcf5d87a741) | `nixos/kubernetes: fix containerd settings`                                   |
| [`b6fbbe76`](https://github.com/NixOS/nixpkgs/commit/b6fbbe768db173f1126c2abb3d84d6d423ffe4da) | `nixos/containerd: use v2 settings by default`                                |
| [`69b52d2b`](https://github.com/NixOS/nixpkgs/commit/69b52d2bdf66c90554ea7a6acc2c22d226244190) | `git-machete: switch to github version to enable tests`                       |
| [`24d13eb0`](https://github.com/NixOS/nixpkgs/commit/24d13eb04008ab80e3c0c012e9b6aa5d35397fc7) | `python3Packages.fpyutils: 2.0.0 -> 2.0.1`                                    |
| [`713ebe34`](https://github.com/NixOS/nixpkgs/commit/713ebe34dff6fa8bb0d27d1c76d5004183c73b66) | `python3Packages.casbin: add missing dependency`                              |
| [`e28643aa`](https://github.com/NixOS/nixpkgs/commit/e28643aa3d72b1380bf7d5a0d98745802f7374bc) | `conmon: 2.0.29 -> 2.0.30`                                                    |
| [`70ba7942`](https://github.com/NixOS/nixpkgs/commit/70ba7942665635af97fb161c910d9b24cad8174e) | `discord-canary: 0.0.130 -> 0.0.131`                                          |
| [`a343985a`](https://github.com/NixOS/nixpkgs/commit/a343985ac2b9a34ac8a76f0f6a15f78e5e86d7b8) | `discord-ptb: 0.0.25 -> 0.0.26`                                               |
| [`b23cf25c`](https://github.com/NixOS/nixpkgs/commit/b23cf25c51f04312fd6448711b15cc99aa5667bd) | `npiet: init at 1.3f`                                                         |
| [`6893c29f`](https://github.com/NixOS/nixpkgs/commit/6893c29faa3632c7188e4c20816a4ee601381e4b) | `kappanhang: init at 1.3`                                                     |
| [`b30b4dd5`](https://github.com/NixOS/nixpkgs/commit/b30b4dd510f96625d2d931d022f74a7e4652d581) | `maintainers: add mvs`                                                        |
| [`c36ec028`](https://github.com/NixOS/nixpkgs/commit/c36ec028c549445af7524d374ab152196de84d7b) | `deltachat-desktop: 1.21.1 -> 1.22.1`                                         |
| [`e78b3161`](https://github.com/NixOS/nixpkgs/commit/e78b3161d286fcf1a49ee939d9d942063a56a492) | `python3Packages.smbprotocol: 1.6.2 -> 1.7.0`                                 |
| [`e1fcd564`](https://github.com/NixOS/nixpkgs/commit/e1fcd5644ec9fdf3272e39b87a21b30fca9d73f7) | `python3Packages.types-requests: 2.25.6 -> 2.25.8`                            |
| [`340eef11`](https://github.com/NixOS/nixpkgs/commit/340eef1127c1841061b7fd0ea3700997e535dd09) | `fluxcd: add updateScript (#138776)`                                          |
| [`3cc8fbf6`](https://github.com/NixOS/nixpkgs/commit/3cc8fbf68f86c5453836115aecfaf6ec282abaa1) | `efm-langserver: 0.0.36 -> 0.0.37`                                            |
| [`3fac6d65`](https://github.com/NixOS/nixpkgs/commit/3fac6d6542f99d8b196b4719cc57246152d46546) | `fst: 0.4.5 -> 0.4.7`                                                         |
| [`0a192fa3`](https://github.com/NixOS/nixpkgs/commit/0a192fa3bcd4756db11f5b0d40e1683b4686744c) | `python3Packages.pyp: init at 0.3.4`                                          |
| [`eb1db6ee`](https://github.com/NixOS/nixpkgs/commit/eb1db6ee71508c0c9e51f36c025ac20a4dd669c4) | `python38Packages.azure-mgmt-containerinstance: 8.0.0 -> 9.0.0`               |
| [`5d6761be`](https://github.com/NixOS/nixpkgs/commit/5d6761be60e23caf72b72488576d6f9f4525cb94) | `kalker: use system gmp to fix aarch64-darwin`                                |
| [`82590fed`](https://github.com/NixOS/nixpkgs/commit/82590fed5fe04aa2503e36e81c84b1e3455780e5) | `glibcLocales: Fix build for duplicates in locales list`                      |
| [`91d925e8`](https://github.com/NixOS/nixpkgs/commit/91d925e85bbc5edf1d04ded77ea3545763f4cac7) | `grsync: 1.2.8 -> 1.3.0`                                                      |
| [`d52201bc`](https://github.com/NixOS/nixpkgs/commit/d52201bc4dc27da0a23da4e8e8b96e2be221eeea) | `python38Packages.aioesphomeapi: 9.1.0 -> 9.1.1`                              |
| [`4c513c6b`](https://github.com/NixOS/nixpkgs/commit/4c513c6b65d3dd0765862cc5b8a13b3ef231464c) | `unifont_upper: 13.0.06 -> 14.0.01`                                           |
| [`f74776f8`](https://github.com/NixOS/nixpkgs/commit/f74776f8cee65fcd5c87c90db5cfc3b78cfbd9c0) | `unifont: 13.0.06 -> 14.0.01`                                                 |
| [`3ba268b7`](https://github.com/NixOS/nixpkgs/commit/3ba268b73d41699edfaafb9a23052f291dfb9ac4) | `kstars: 3.5.4 -> 3.5.5`                                                      |
| [`dc032a86`](https://github.com/NixOS/nixpkgs/commit/dc032a866bbc68c219f0746f40f09679796cd296) | `libbfd: add libintl dependency for darwin.`                                  |
| [`11bf0ac2`](https://github.com/NixOS/nixpkgs/commit/11bf0ac25ba3a87f574f4b896646ebb2581edadf) | `pythonPackages.libgpuarray: fix opengl runpath`                              |
| [`ffc40e31`](https://github.com/NixOS/nixpkgs/commit/ffc40e31aca81c18da13ce7eefa464af62747f17) | `ursadb: switch to fetchFromGitHub`                                           |
| [`5d982374`](https://github.com/NixOS/nixpkgs/commit/5d982374d011dfa95d940d96e79a16022d032ec2) | `slimserver: switch to fetchFromGitHub`                                       |
| [`67764397`](https://github.com/NixOS/nixpkgs/commit/677643972fb428e709832d9be4afba364e367854) | `apacheHttpdPackages.mod_wsgi: switch to fetchFromGitHub`                     |
| [`c85679ef`](https://github.com/NixOS/nixpkgs/commit/c85679ef62f5071bf548759b190ea071684aaa6b) | `apacheHttpdPackages.mod_fastcgi: switch to fetchFromGitHub & mark as broken` |
| [`3c122940`](https://github.com/NixOS/nixpkgs/commit/3c12294098762298166a210558c781df092b9846) | `fcgiwrap: switch to fetchFromGitHub`                                         |
| [`d69406b8`](https://github.com/NixOS/nixpkgs/commit/d69406b88cfb6a21a69e376da0b5fb44f97ba4eb) | `couchpotato: switch to fetchFromGitHub`                                      |
| [`3d9480f7`](https://github.com/NixOS/nixpkgs/commit/3d9480f720d861d718487aa2c5fc9b6b8370a47a) | `beanstalkd: switch to fetchFromGitHub`                                       |
| [`63b1f69a`](https://github.com/NixOS/nixpkgs/commit/63b1f69a6deaf31596d57f78fcb4f521b1de9109) | `angelfish: 21.06 -> 21.08`                                                   |
| [`1c0d8b47`](https://github.com/NixOS/nixpkgs/commit/1c0d8b479803a3642a85f778017c0554d229d008) | `skytemple: 1.3.0 -> 1.3.1`                                                   |
| [`360ac489`](https://github.com/NixOS/nixpkgs/commit/360ac489b8706a9e8202e03856ca87d2f7706d01) | `python3Packages.skytemple-files: 1.3.0 -> 1.3.1`                             |
| [`b25f877b`](https://github.com/NixOS/nixpkgs/commit/b25f877b355d104daa19560c0df0bae3a8c7ecbc) | `osrm-backend: 5.25.0 -> 5.26.0`                                              |
| [`54c3a9d6`](https://github.com/NixOS/nixpkgs/commit/54c3a9d6f8a5da4b2e3bff7d75599f6f212a3db0) | `zoom-us: 5.7.31792.0820 -> 5.8.0.16`                                         |