### PR TITLE
fix update deps cron

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -1,7 +1,7 @@
 name: Update Dependencies
 on:
   schedule:
-    - cron: "* */2 * * *"
+    - cron: "0 */6 * * *"
   workflow_dispatch:
 jobs:
   niv-update:


### PR DESCRIPTION
- ci: bump node version
- ci: rename to CI
- ci: give the checkout step a name
- ci: give the bot its proper name
- ci: lower case step names
- ci: run update deps every 6 hours
