### PR TITLE
fix: use double ticks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ async function generateTableLines(
           `[${TICK}${sha}${TICK}](${shaUrl})`,
           // spaces are here to handle embedded backticks
           // github will remove the spaces in the rendered text
-          `${TICK} ${commitMessage} ${TICK}`,
+          `${TICK}${TICK} ${commitMessage} ${TICK}${TICK}`,
         ]);
       }
     }


### PR DESCRIPTION
- chore: fix package lock
- fix(deps): bump to node16 everywhere
- fix: let github handle backticks
- chore: remove npm run test from npm run all script
- chore: dist
- fix: use double ticks
